### PR TITLE
Test homebrew release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ release {
 }
 
 group = 'hedera-cli'
-version = '0.0.1'
+// version is specified in gradle.properties
 
 repositories {
     // Use jcenter for resolving dependencies.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.2
+version=0.0.3

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,16 +1,5 @@
 #!/bin/sh
 
-# clean gradle
-echo "cleaning up the ocean..."
-./gradlew clean
-
 # build gradle
-echo "rebuilding the world..."
+echo "clean, build (and, by default, test)"
 ./gradlew clean build
-
-# copy out the executable jar built with Spring Boot's LaunchScript
-cp build/libs/hedera-cli-0.0.1.jar hedera && chmod +x hedera
-
-# once the hedera executable is moved to a PATH directory,
-# it should be available anywhere as a command line program
-echo "\nhedera binary created in this directory.\nMove hedera binary to your PATH.\n"

--- a/scripts/package_homebrew.sh
+++ b/scripts/package_homebrew.sh
@@ -7,6 +7,8 @@ cd ${HOMEBREW_TAP_REPO}
 
 ./scripts/sha256update.rb "${GH_REPO}"
 
+git config --global user.name "OSS Hedera"
+git config --global user.email "oss@hedera.com"
 git add -u
 git commit -m "${GH_REPO} ${VERSION} release"
 git push

--- a/scripts/package_homebrew.sh
+++ b/scripts/package_homebrew.sh
@@ -5,7 +5,7 @@ HOMEBREW_TAP_REPO=homebrew-tap
 git clone git@github.com:${GH_USER}/${HOMEBREW_TAP_REPO}.git
 cd ${HOMEBREW_TAP_REPO}
 
-./sha256update.rb "${GH_REPO}"
+./scripts/sha256update.rb "${GH_REPO}"
 
 git add -u
 git commit -m "${GH_REPO} ${VERSION} release"

--- a/scripts/package_homebrew.sh
+++ b/scripts/package_homebrew.sh
@@ -10,3 +10,5 @@ cd ${HOMEBREW_TAP_REPO}
 git add -u
 git commit -m "${GH_REPO} ${VERSION} release"
 git push
+
+cd ..

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,11 @@ NAME=hedera
 
 PACKAGE="${NAME}-${VERSION}.tar.gz"
 
-tar -zcvf "${PACKAGE}" .
+# copy out the executable jar built with Spring Boot's LaunchScript
+cp build/libs/"${GH_REPO}-${VERSION}.jar" hedera && chmod +x hedera
+
+# pack only our hedera binary
+tar -zcvf "${PACKAGE}" hedera
 
 SHA256="$(sha256sum ${PACKAGE} | cut -d' ' -f1)"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,7 +44,7 @@ file_name=${NAME}-${VERSION}.tar.gz
 curl --user "$GH_USER:$GH_PATH" -X POST https://uploads.github.com/repos/${GH_USER}/${GH_REPO}/releases/${rel_id}/assets?name=${file_name}\
  --header 'Content-Type: text/javascript ' --upload-file ${ASSETS_PATH}/${file_name}
 
-source package_homebrew.sh
+source ./scripts/package_homebrew.sh
 
 # clean up
 rm ${ASSETS_PATH}/${file_name}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,10 +14,12 @@ export GH_REPO=hedera-cli
 GH_TARGET=master
 ASSETS_PATH=.
 NAME=hedera
-SHA256="$(sha256sum ${NAME}-${VERSION}.tar.gz | cut -d' ' -f1)"
+
 PACKAGE="${NAME}-${VERSION}.tar.gz"
 
 tar -zcvf "${PACKAGE}" .
+
+SHA256="$(sha256sum ${PACKAGE} | cut -d' ' -f1)"
 
 git add -u
 git commit -m "$VERSION release"


### PR DESCRIPTION
Automate homebrew formula update, so we avoid the trouble of having to manually update `hashgraph/homebrew-tap`.