### PR TITLE
Fix broken commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,11 +88,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'org.springframework.shell:spring-shell-starter:2.0.1.RELEASE'
 
-    // Use JUnit test framework
-    testImplementation 'junit:junit:4.12'
-    
-    // Mockito for JUnit
+    // Mockito and JUnit 5
+    testImplementation('org.junit.jupiter:junit-jupiter-api:5.2.0')
+    testCompile('org.junit.jupiter:junit-jupiter-params:5.2.0')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
     testCompile "org.mockito:mockito-core:2.+"
+    testCompile('org.mockito:mockito-junit-jupiter:2.18.3')
     testCompile "org.springframework.boot:spring-boot-starter-test"
 }
 

--- a/src/main/java/com/hedera/cli/hedera/Hedera.java
+++ b/src/main/java/com/hedera/cli/hedera/Hedera.java
@@ -82,7 +82,7 @@ public class Hedera {
         String value;
         String privateKey = "";
 
-        Map<String, String> readingIndexAccount = dataDirectory.readFileHashmap(pathToIndexTxt);
+        Map<String, String> readingIndexAccount = dataDirectory.readIndexToHashmap(pathToIndexTxt);
         for(Map.Entry<String, String> entry : readingIndexAccount.entrySet()) {
             accountId = entry.getKey(); // key refers to the account id
             value = entry.getValue(); // value refers to the filename json
@@ -105,7 +105,7 @@ public class Hedera {
         String accountId;
         String value;
 
-        Map<String, String> readingIndexAccount = dataDirectory.readFileHashmap(pathToIndexTxt);
+        Map<String, String> readingIndexAccount = dataDirectory.readIndexToHashmap(pathToIndexTxt);
         for(Map.Entry<String, String> entry : readingIndexAccount.entrySet()) {
             accountId = entry.getKey(); // key refers to the account id
             value = entry.getValue(); // value refers to the filename json

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountDelete.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountDelete.java
@@ -1,31 +1,33 @@
 package com.hedera.cli.hedera.crypto;
 
-import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
 import com.hedera.cli.config.InputReader;
 import com.hedera.cli.hedera.Hedera;
 import com.hedera.cli.hedera.utils.AccountUtils;
 import com.hedera.cli.hedera.utils.DataDirectory;
 import com.hedera.cli.shell.ShellHelper;
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.account.AccountDeleteTransaction;
 import com.hedera.hashgraph.sdk.account.AccountId;
-
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
-import lombok.Getter;
-import lombok.Setter;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
+import lombok.Getter;
+import lombok.Setter;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-
-import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
+import picocli.CommandLine.Spec;
 
 @Getter
 @Setter
@@ -138,7 +140,7 @@ public class AccountDelete implements Runnable {
         String pathToCurrentJsonAccount;
         Map<String, String> updatedMap;
 
-        Map<String, String> readingIndexAccount = dataDirectory.readFileHashmap(pathToIndexTxt);
+        Map<String, String> readingIndexAccount = dataDirectory.readIndexToHashmap(pathToIndexTxt);
 
         Set<Map.Entry<String, String>> setOfEntries = readingIndexAccount.entrySet();
         Iterator<Map.Entry<String, String>> iterator = setOfEntries.iterator();

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountDelete.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountDelete.java
@@ -161,7 +161,7 @@ public class AccountDelete implements Runnable {
         }
         // write to file
         updatedMap = readingIndexAccount;
-        dataDirectory.writeFile(pathToIndexTxt, updatedMap.toString());
+        dataDirectory.writeFile(pathToIndexTxt, dataDirectory.formatMapToIndex(updatedMap));
         return fileDeleted;
     }
 }

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountRecovery.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountRecovery.java
@@ -1,7 +1,6 @@
 package com.hedera.cli.hedera.crypto;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -125,7 +124,7 @@ public class AccountRecovery implements Runnable {
         AccountUtils accountUtils = new AccountUtils();
         String pathToIndexTxt = accountUtils.pathToIndexTxt();
         boolean accountExists = false;
-        HashMap<String, String> readingIndexAccount = dataDirectory.readFileHashmap(pathToIndexTxt);
+        Map<String, String> readingIndexAccount = dataDirectory.readIndexToHashmap(pathToIndexTxt);
         for (Map.Entry<String, String> entry : readingIndexAccount.entrySet()) {
             if (entry.getKey().equals(accountId)) {
                 accountExists = true;

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
@@ -14,7 +14,6 @@ import lombok.Getter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
-// @formatter:off
 @Getter
 @Component
 @Command(name = "use", 

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
@@ -25,7 +25,9 @@ public class AccountUse implements Runnable {
     @Autowired
     ApplicationContext context;
 
-    @Parameters(index = "0", description = "Hedera account in the format shardNum.realmNum.accountNum")
+    @Parameters(index = "0", description = "Hedera account in the format shardNum.realmNum.accountNum"
+            + "%n@|bold,underline Usage:|@%n"
+            + "@|fg(yellow) account use 0.0.1003|@")
     private String accountId;
 
     @Override

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
@@ -1,7 +1,6 @@
 package com.hedera.cli.hedera.crypto;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 
 import com.hedera.cli.hedera.utils.DataDirectory;

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
@@ -2,6 +2,7 @@ package com.hedera.cli.hedera.crypto;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.hedera.cli.hedera.utils.DataDirectory;
 import com.hedera.cli.services.CurrentAccountService;
@@ -48,11 +49,11 @@ public class AccountUse implements Runnable {
      * @param dataDirectory
      * @return boolean accountIdExists
      */
-    private boolean accountIdExistsInIndex(DataDirectory dataDirectory, String accountId) {
+    public boolean accountIdExistsInIndex(DataDirectory dataDirectory, String accountId) {
         String networkName = dataDirectory.readFile("network.txt");
         String pathToAccountsFolder = networkName + File.separator + "accounts" + File.separator;
         String pathToIndexTxt = pathToAccountsFolder + "index.txt";
-        HashMap<String, String> readingIndexAccount = dataDirectory.readFileHashmap(pathToIndexTxt);
+        Map<String, String> readingIndexAccount = dataDirectory.readIndexToHashmap(pathToIndexTxt);
         for (Object key : readingIndexAccount.keySet()) {
             if (accountId.equals(key.toString())) {
                 return true;

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
@@ -10,22 +10,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import lombok.Getter;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Spec;
+import picocli.CommandLine.Parameters;
 
+// @formatter:off
+@Getter
 @Component
-@Command(name = "use", description = "@|fg(225) Allows to toggle between multiple Hedera Accounts|@", helpCommand = true)
+@Command(name = "use", 
+        separator = " ", 
+        description = "@|fg(225) Switch to use a specific Hedera account as operator.|@",
+        helpCommand = true) // @formatter:on
 public class AccountUse implements Runnable {
 
     @Autowired
     ApplicationContext context;
 
-    @Spec
-    CommandSpec spec;
-
-    @Option(names = { "-a", "--accountId" }, description = "Account ID in %nshardNum.realmNum.accountNum format")
+    @Parameters(index = "0", description = "Hedera account in the format shardNum.realmNum.accountNum")
     private String accountId;
 
     @Override
@@ -48,7 +49,7 @@ public class AccountUse implements Runnable {
      * @param dataDirectory
      * @return boolean accountIdExists
      */
-    public boolean accountIdExistsInIndex(DataDirectory dataDirectory, String accountId) {
+    private boolean accountIdExistsInIndex(DataDirectory dataDirectory, String accountId) {
         String networkName = dataDirectory.readFile("network.txt");
         String pathToAccountsFolder = networkName + File.separator + "accounts" + File.separator;
         String pathToIndexTxt = pathToAccountsFolder + "index.txt";
@@ -62,3 +63,4 @@ public class AccountUse implements Runnable {
     }
 
 }
+

--- a/src/main/java/com/hedera/cli/hedera/setup/Setup.java
+++ b/src/main/java/com/hedera/cli/hedera/setup/Setup.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.hedera.cli.config.InputReader;
@@ -22,15 +21,12 @@ import com.hedera.cli.models.RecoveredAccountModel;
 import com.hedera.cli.shell.ShellHelper;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 
-
 import org.hjson.JsonObject;
 import org.springframework.stereotype.Component;
-
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Spec;
 
 

--- a/src/main/java/com/hedera/cli/hedera/utils/DataDirectory.java
+++ b/src/main/java/com/hedera/cli/hedera/utils/DataDirectory.java
@@ -10,10 +10,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -174,7 +171,7 @@ public class DataDirectory {
         boolean fileExists = Files.exists(filePath);
         if (!fileExists) {
             // file does not exist so create a new file and write value
-            String cleanedIndexTxt = defaultValue.toString().substring(1,defaultValue.toString().length()-1);
+            String cleanedIndexTxt = defaultValue.toString().substring(1, defaultValue.toString().length() - 1);
             writeFile(pathToFile, cleanedIndexTxt);
             return defaultValue;
         }
@@ -203,7 +200,7 @@ public class DataDirectory {
             // appends old map with new value
             updatedHashmap.put(key, value);
             // write to file
-            String cleanedIndexTxtUpdated = updatedHashmap.toString().substring(1,updatedHashmap.toString().length()-1);
+            String cleanedIndexTxtUpdated = updatedHashmap.toString().substring(1, updatedHashmap.toString().length() - 1);
             writeFile(pathToFile, cleanedIndexTxtUpdated.replace(", ", "\n"));
             reader.close();
             return updatedHashmap;
@@ -217,7 +214,6 @@ public class DataDirectory {
         // check if index.txt exists, if not, create one
         Path filePath = Paths.get(userHome, directoryName, pathToFile);
         File file = new File(filePath.toString());
-        HashMap<String, String> mHashmap = new HashMap<>();
 
         try {
             // file exist
@@ -231,6 +227,31 @@ public class DataDirectory {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    public Map<String, String> readIndexToHashmap(String pathToFile) {
+        // check if index.txt exists, if not, create one
+        Path filePath = Paths.get(userHome, directoryName, pathToFile);
+        File file = new File(filePath.toString());
+        HashMap<String, String> mHashmap = new HashMap<>();
+
+        try {
+            // file exist
+            Scanner reader = new Scanner(file);
+            while (reader.hasNext()) {
+                // checks the old map
+                String line = reader.nextLine();
+                String[] splitLines = line.split("\n");
+                for (int i = 0; i < splitLines.length; i++) {
+                    String[] keyValuePairs = splitLines[i].split("=");
+                    mHashmap.put(keyValuePairs[0], keyValuePairs[1]);
+                }
+            }
+            reader.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return mHashmap;
     }
 
     public HashMap<String, String> readFileHashmap(String pathToFile) {

--- a/src/main/java/com/hedera/cli/hedera/utils/DataDirectory.java
+++ b/src/main/java/com/hedera/cli/hedera/utils/DataDirectory.java
@@ -174,8 +174,7 @@ public class DataDirectory {
         boolean fileExists = Files.exists(filePath);
         if (!fileExists) {
             // file does not exist so create a new file and write value
-            String cleanedIndexTxt = defaultValue.toString().substring(1, defaultValue.toString().length() - 1);
-            writeFile(pathToFile, cleanedIndexTxt);
+            writeFile(pathToFile, formatMapToIndex(defaultValue));
             return defaultValue;
         }
 
@@ -203,14 +202,19 @@ public class DataDirectory {
             // appends old map with new value
             updatedHashmap.put(key, value);
             // write to file
-            String cleanedIndexTxtUpdated = updatedHashmap.toString().substring(1, updatedHashmap.toString().length() - 1);
-            writeFile(pathToFile, cleanedIndexTxtUpdated.replace(", ", "\n"));
+            writeFile(pathToFile, formatMapToIndex(updatedHashmap));
             reader.close();
             return updatedHashmap;
         } catch (Exception e) {
             e.printStackTrace();
         }
         return defaultValue;
+    }
+
+    public String formatMapToIndex(Map<String, String> updatedHashmap) {
+        return updatedHashmap.toString()
+                .substring(1, updatedHashmap.toString().length() - 1)
+                .replace(", ", "\n");
     }
 
     public void readIndex(String pathToFile) {

--- a/src/main/java/com/hedera/cli/hedera/utils/DataDirectory.java
+++ b/src/main/java/com/hedera/cli/hedera/utils/DataDirectory.java
@@ -10,7 +10,10 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/test/java/com/hedera/cli/hedera/crypto/AccountListTest.java
+++ b/src/test/java/com/hedera/cli/hedera/crypto/AccountListTest.java
@@ -1,6 +1,6 @@
 package com.hedera.cli.hedera.crypto;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -9,14 +9,30 @@ import java.util.Map;
 import com.hedera.cli.hedera.utils.AccountUtils;
 import com.hedera.cli.hedera.utils.DataDirectory;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class AccountListTest {
+
+    @InjectMocks
+    AccountUtils accountUtils;
+
+    @Mock
+    DataDirectory dataDirectory;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     public void testStreamList() {
-        AccountUtils accountUtils = new AccountUtils();
         String pathToIndexTxt = accountUtils.pathToIndexTxt();
 
         HashMap<String, String> testMap = new HashMap<>();
@@ -27,9 +43,8 @@ public class AccountListTest {
         testMap.put("0.0.112232", "definitive_forsythia_2853");
         testMap.put("0.0.8888", "sorrowful_geranium_7578");
 
-        DataDirectory dataDirectory = Mockito.mock(DataDirectory.class);
         when(dataDirectory.readIndexToHashmap(pathToIndexTxt)).thenReturn(testMap);
         Map<String, String> readingIndexAccount = dataDirectory.readIndexToHashmap(pathToIndexTxt);
-        assertEquals(readingIndexAccount.entrySet(), testMap.entrySet());
+        assertTrue(readingIndexAccount.entrySet().equals(testMap.entrySet()));
     }
 }

--- a/src/test/java/com/hedera/cli/hedera/crypto/AccountListTest.java
+++ b/src/test/java/com/hedera/cli/hedera/crypto/AccountListTest.java
@@ -1,15 +1,16 @@
 package com.hedera.cli.hedera.crypto;
 
-import com.hedera.cli.hedera.utils.AccountUtils;
-import com.hedera.cli.hedera.utils.DataDirectory;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import com.hedera.cli.hedera.utils.AccountUtils;
+import com.hedera.cli.hedera.utils.DataDirectory;
+
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class AccountListTest {
 
@@ -27,8 +28,8 @@ public class AccountListTest {
         testMap.put("0.0.8888", "sorrowful_geranium_7578");
 
         DataDirectory dataDirectory = Mockito.mock(DataDirectory.class);
-        when(dataDirectory.readFileHashmap(pathToIndexTxt)).thenReturn(testMap);
-        Map<String, String> readingIndexAccount = dataDirectory.readFileHashmap(pathToIndexTxt);
+        when(dataDirectory.readIndexToHashmap(pathToIndexTxt)).thenReturn(testMap);
+        Map<String, String> readingIndexAccount = dataDirectory.readIndexToHashmap(pathToIndexTxt);
         assertEquals(readingIndexAccount.entrySet(), testMap.entrySet());
     }
 }

--- a/src/test/java/com/hedera/cli/hedera/crypto/AccountUseTest.java
+++ b/src/test/java/com/hedera/cli/hedera/crypto/AccountUseTest.java
@@ -1,10 +1,14 @@
 package com.hedera.cli.hedera.crypto;
 
+import com.hedera.cli.hedera.utils.DataDirectory;
+import org.junit.Test;
+
 public class AccountUseTest {
 
-//    @Test
-//    public void testAccountSwitch() {
-//        AccountUse accountUse = new AccountUse();
-//        accountUse.switchAccount();
-//    }
+    @Test
+    public void testAccountSwitch() {
+        AccountUse accountUse = new AccountUse();
+        DataDirectory dataDirectory = new DataDirectory();
+        accountUse.accountIdExistsInIndex(dataDirectory, "0.0.1003");
+    }
 }

--- a/src/test/java/com/hedera/cli/hedera/crypto/AccountUseTest.java
+++ b/src/test/java/com/hedera/cli/hedera/crypto/AccountUseTest.java
@@ -1,14 +1,36 @@
 package com.hedera.cli.hedera.crypto;
 
-import com.hedera.cli.hedera.utils.DataDirectory;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import picocli.CommandLine;
+import picocli.CommandLine.MissingParameterException;
+
+@ExtendWith(MockitoExtension.class)
 public class AccountUseTest {
 
-    @Test
-    public void testAccountSwitch() {
-        AccountUse accountUse = new AccountUse();
-        DataDirectory dataDirectory = new DataDirectory();
-        accountUse.accountIdExistsInIndex(dataDirectory, "0.0.1003");
-    }
+  @Test
+  public void testAccountUseWithNoArgs() {
+    String[] args = new String[]{};
+    CommandLine cmd = new CommandLine(AccountUse.class);
+    assertThrows(MissingParameterException.class, () -> {
+        cmd.parseArgs(args);
+    });
+    AccountUse accountUse = cmd.getCommand();
+    assertNull(accountUse.getAccountId());
+  }
+
+  @Test
+  public void testAccountUseWithAccountId() {
+    String[] args = new String[]{ "0.0.1001" };
+    CommandLine cmd = new CommandLine(AccountUse.class);
+    cmd.parseArgs(args);
+    AccountUse accountUse = cmd.getCommand();
+    assertEquals("0.0.1001", accountUse.getAccountId());
+  }
 }


### PR DESCRIPTION
By using `@Mock` to denote the dependency that we are mocking, and by using `@InjectMocks` to initialise the class under test `AccountUtils`, we are able to correctly isolate our unit tests to exercise our class under test, without its dependency (`DataDirectory` in this case) creating NullException errors.

This is the general approach we should take for unit tests to increase our confidence level on the Picocli classes we have implemented and for ShellComponent (Spring Shell) classes we have implemented.

Required as part of the hotfix for current issue on this branch, and is related to broader implementation of tests mentioned in #43. Broader implementation of unit tests will be made in a separate PR for #43.  