### PR TITLE
43 hotfix

### DIFF
--- a/src/main/java/com/hedera/cli/hedera/Hedera.java
+++ b/src/main/java/com/hedera/cli/hedera/Hedera.java
@@ -44,6 +44,7 @@ public class Hedera {
     // Our operator account is returned, in order of priority,
     // current account, default account, no account (empty string)
     public String getOperatorAccount() {
+
         // is there an in-memory current account?
         String currentAccount = currentAccountId();
         if (!StringUtil.isNullOrEmpty(currentAccount)) {
@@ -107,7 +108,12 @@ public class Hedera {
 
     public String currentAccountId() {
         CurrentAccountService currentAccountService = context.getBean("currentAccount", CurrentAccountService.class);
-        return currentAccountService.getAccountNumber();
+        String network = currentAccountService.getNetwork();
+        String currentNetwork = addressBookManager.getCurrentNetworkAsString();
+        if (currentNetwork.equals(network)) {
+            return currentAccountService.getAccountNumber();
+        }
+        return "";
     }
 
     public String retrieveIndexAccountKeyInHexString() {

--- a/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
+++ b/src/main/java/com/hedera/cli/hedera/crypto/AccountUse.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.Map;
 
 import com.hedera.cli.config.InputReader;
+import com.hedera.cli.hedera.Hedera;
+import com.hedera.cli.models.AddressBookManager;
 import com.hedera.cli.models.DataDirectory;
 import com.hedera.cli.services.CurrentAccountService;
 
@@ -29,6 +31,9 @@ public class AccountUse implements Runnable, Operation {
     private ApplicationContext context;
 
     @Autowired
+    private Hedera hedera;
+
+    @Autowired
     private DataDirectory dataDirectory;
 
     @Parameters(index = "0", description = "Hedera account in the format shardNum.realmNum.accountNum"
@@ -40,9 +45,12 @@ public class AccountUse implements Runnable, Operation {
         boolean exists = accountIdExistsInIndex(dataDirectory, accountId);
         if (exists) {
             // since this accountId exists, we set it into our CurrentAccountService
-            // singleton
+            // singleton and ensure that we know that this account is only for the specified network
             CurrentAccountService currentAccountService = (CurrentAccountService) context.getBean("currentAccount",
                     CurrentAccountService.class);
+            AddressBookManager addressBookManager = hedera.getAddressBookManager();
+            String network = addressBookManager.getCurrentNetworkAsString();
+            currentAccountService.setNetwork(network);
             currentAccountService.setAccountNumber(accountId);
         } else {
             System.out.println("This account does not exist, please add new account using `account recovery`");

--- a/src/main/java/com/hedera/cli/services/CurrentAccountService.java
+++ b/src/main/java/com/hedera/cli/services/CurrentAccountService.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 @Service
 public class CurrentAccountService {
 
+  private String network;
   private String accountNumber;
   private String privateKey;
   private String publicKey;

--- a/src/test/java/com/hedera/cli/hedera/crypto/CryptoTransferTest.java
+++ b/src/test/java/com/hedera/cli/hedera/crypto/CryptoTransferTest.java
@@ -293,6 +293,6 @@ public class CryptoTransferTest {
         expectedMap.put(1, previewTransferList1);
 
         Map<Integer, PreviewTransferList> actualMap = cryptoTransfer.transferListToPromptPreviewMap(transferList, amountList);
-        assertEquals(expectedMap.get("0.0.116681"), actualMap.get("0.0.116681"));
+        assertEquals(expectedMap.get(0).getAccountId(), actualMap.get(0).getAccountId());
     }
 }

--- a/src/test/java/com/hedera/cli/services/CurrentAccountServiceTest.java
+++ b/src/test/java/com/hedera/cli/services/CurrentAccountServiceTest.java
@@ -9,10 +9,12 @@ public class CurrentAccountServiceTest {
   public void settersAndGetters() {
     CurrentAccountService c = new CurrentAccountService();
 
+    c.setNetwork("testnet");
     c.setAccountNumber("0.0.1001");
     c.setPrivateKey("somePrivateKey");
     c.setPublicKey("somePublicKey");
 
+    assertEquals("testnet", c.getNetwork());
     assertEquals("0.0.1001", c.getAccountNumber());
     assertEquals("somePrivateKey", c.getPrivateKey());
     assertEquals("somePublicKey", c.getPublicKey());


### PR DESCRIPTION
Fixes the network-awareness bug relating to in-memory accounts.

This fix ensures that our `account use 0.0.1001` (in-memory current account) capability is network-aware as discussed.

Good catch.