### PR TITLE
Control characters in tests result in flakey tests

### DIFF
--- a/src/test/java/com/hedera/cli/shell/ProgressBarTest.java
+++ b/src/test/java/com/hedera/cli/shell/ProgressBarTest.java
@@ -55,7 +55,7 @@ public class ProgressBarTest {
     int length = allLines.size();
     String lastLine = allLines.get(length - 1).trim();
     String[] lastLineArray = lastLine.stripTrailing().split(" ");
-    String last = lastLineArray[lastLineArray.length - 1];
+    String last = lastLineArray[lastLineArray.length - 1].trim().replaceAll("\\p{C}+", "");
 
     assertEquals(100, length);
     assertEquals("100%", last);
@@ -84,14 +84,15 @@ public class ProgressBarTest {
     int length = allLines.size();
     String lastLine = allLines.get(length - 1).trim();
     String[] lastLineArray = lastLine.stripTrailing().split(" ");
-    String last = lastLineArray[lastLineArray.length - 1];
+    String last = lastLineArray[lastLineArray.length - 1].trim().replaceAll("\\p{C}+", "");
 
     assertEquals(100, length);
     assertEquals(testMessage, last);
   }
 
   private String captureLine() {
-    return new String(output.toByteArray());
+    String capturedString = new String(output.toByteArray());
+    return capturedString.trim().replaceAll("\\p{C}+", ""); // always escape control characters
   }
 
 }

--- a/src/test/java/com/hedera/cli/shell/ProgressCounterTest.java
+++ b/src/test/java/com/hedera/cli/shell/ProgressCounterTest.java
@@ -73,8 +73,9 @@ public class ProgressCounterTest {
     String[] allLinesArray = allLinesString.trim().split("\n");
     String lastLine = allLinesArray[allLinesArray.length - 1];
     String[] lastLineArray = lastLine.trim().split(" ");
-    String lastWord = lastLineArray[lastLineArray.length - 1];
-    String secondLastWord = lastLineArray[lastLineArray.length - 2];
+    // ? character gets added in randomly, so we explicitly remove it if it exists
+    String lastWord = lastLineArray[lastLineArray.length - 1].trim().replaceAll("\\p{C}+", "");
+    String secondLastWord = lastLineArray[lastLineArray.length - 2].trim().replaceAll("\\p{C}+", "");
 
     assertEquals("100", lastWord);
     assertEquals("hello:", secondLastWord);
@@ -117,7 +118,8 @@ public class ProgressCounterTest {
   }
 
   private String captureLine() {
-    return new String(output.toByteArray());
+    String capturedString = new String(output.toByteArray());
+    return capturedString.trim().replaceAll("\\p{C}+", ""); // always escape control characters
   }
 
 }

--- a/src/test/java/com/hedera/cli/shell/ShellHelperTest.java
+++ b/src/test/java/com/hedera/cli/shell/ShellHelperTest.java
@@ -122,8 +122,9 @@ public class ShellHelperTest {
 
   @Test
   public void print() throws IOException {
-    shellHelper2.print(testMessage); // print uses default color
-    String line = captureLine().trim();
+    // print uses default color
+    shellHelper2.print(testMessage); 
+    String line = captureLine();
     assertEquals(testMessage, line);
   }
 
@@ -131,17 +132,19 @@ public class ShellHelperTest {
   public void printInfo() {
     shellHelper2.printInfo(testMessage);
     String ansiLine = ANSI.get("CYAN") + testMessage + ANSI.get("RESET");
-    String expected = ansiLine.trim();
-    String actual = captureLine().trim();
+    String expected = ansiLine.trim().replaceAll("\\p{C}+", "");
+    String actual = captureLine();
     assertEquals(expected, actual);
   }
 
   @Test
   public void printSuccess() {
-    shellHelper2.printSuccess(testMessage);
     String ansiLine = ANSI.get("GREEN") + testMessage + ANSI.get("RESET");
-    String expected = ansiLine.trim();
-    String actual = captureLine().trim();
+    String expected = ansiLine.trim().replaceAll("\\p{C}+", "");
+
+    shellHelper2.printSuccess(testMessage);
+    String actual = captureLine();
+
     assertEquals(expected, actual);
   }
 
@@ -149,8 +152,8 @@ public class ShellHelperTest {
   public void printWarning() {
     shellHelper2.printWarning(testMessage);
     String ansiLine = ANSI.get("YELLOW") + testMessage + ANSI.get("RESET");
-    String expected = ansiLine.trim();
-    String actual = captureLine().trim();
+    String expected = ansiLine.trim().trim().replaceAll("\\p{C}+", "");
+    String actual = captureLine();
     assertEquals(expected, actual);
   }
 
@@ -158,13 +161,14 @@ public class ShellHelperTest {
   public void printError() {
     shellHelper2.printError(testMessage);
     String ansiLine = ANSI.get("RED") + testMessage + ANSI.get("RESET");
-    String expected = ansiLine.trim();
+    String expected = ansiLine.trim().trim().replaceAll("\\p{C}+", "");
     String actual = captureLine().trim();
     assertEquals(expected, actual);
   }
 
   private String captureLine() {
-    return new String(output.toByteArray());
+    String capturedString = new String(output.toByteArray());
+    return capturedString.trim().replaceAll("\\p{C}+", ""); // always escape control characters
   }
 
 }


### PR DESCRIPTION
Specifically problematic in shellHelperTest, ProgressCounterTest and ProgressBarTest. 

Always strip off control characters to ensure consistent, non-flakey tests. 

Fixes #135

Signed-off-by: Calvin Cheng <calvin@hedera.com>