### PR TITLE
Transfer Hbar from operator - Closes #203

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ node dist/hedera-cli.js setup init
 
 > **Note:** You can set a custom absolute path for your `.env` file by using the `--path` flag. For example, `node dist/hedera-cli.js setup init --path /Users/myUser/projects/cli/.env`. More information can be found in the [setup command](#setup-commands) section below.
 
+The `setup init` command will also create the different operator accounts in your address book (`dist/state/state.json` file) so you can use them in your commands.
+
 **4. Verify Installation:**
 
 You can verify the installation by listing all accounts in your address book. If you haven't added any accounts yet, you should see the following output:
@@ -168,7 +170,7 @@ When executed, the setup command performs several key functions:
 It checks if the HOME environment variable is defined and reads `PREVIEWNET_OPERATOR_KEY`, `PREVIEWNET_OPERATOR_KEY`, `TESTNET_OPERATOR_KEY`, `TESTNET_OPERATOR_ID`, `MAINNET_OPERATOR_KEY`, `MAINNET_OPERATOR_ID` from the `~/.hedera/.env` file.
 
 **State Update:**
-Once the previewnet, testnet, and mainnet operator key and ID are validated, these credentials are used to update the `state/state.json` file, which holds the configuration state of the CLI tool.
+Once the previewnet, testnet, and mainnet operator key and ID are validated, these credentials are used to update the `dist/state/state.json` file, which holds the configuration state of the CLI tool. The command will also add the operator accounts to your address book.
 
 **2. Reload Operator Key and Id:**
 
@@ -266,7 +268,7 @@ Flags:
 - **Balance:** (optional) Initial balance in tinybars. Defaults to 1000.
 - **Type:** (optional) The account type (`ECDSA` or `ED25519`). Defaults to `ED25519`.
 
-> **Note:** Setting the **`<alias>` to `random`** will generate a random 20-char long alias. This is useful for scripting functionality to avoid running into non-unique alias errors. 
+> **Note:** Setting the **`<alias>` to `random`** will generate a random 20-char long alias. This is useful for scripting functionality to avoid running into non-unique alias errors. It's not allowed to use the word **operator** as an alias or as part of an alias because it's reserved for the operator accounts.
 
 **2. Retrieve Account Balance:**
 

--- a/__tests__/commands/network/list.test.ts
+++ b/__tests__/commands/network/list.test.ts
@@ -19,7 +19,6 @@ describe("network list command", () => {
         await program.parse(["node", "hedera-cli.ts", "network", "list"]);
   
         // Assert
-        console.log(logSpy.mock.calls)
         expect(logSpy).toHaveBeenCalledWith(`Available networks: mainnet, testnet, previewnet`);
       });
   });

--- a/__tests__/commands/setup.test.ts
+++ b/__tests__/commands/setup.test.ts
@@ -1,5 +1,5 @@
 
-import { baseState, scriptState, script_basic } from '../helpers/state';
+import { baseState, testnetOperatorAccount, testnetOperatorId, testnetOperatorKey } from '../helpers/state';
 import { Command } from 'commander';
 import commands from '../../src/commands';
 
@@ -11,7 +11,6 @@ import setupUtils from '../../src/utils/setup';
 
 jest.mock('os');
 jest.mock('dotenv');
-jest.mock('../../src/utils/account');
 jest.mock('../../src/state/state'); // Mock the original module -> looks for __mocks__/state.ts in same directory
 
 describe('setup init command', () => {
@@ -40,8 +39,6 @@ describe('setup init command', () => {
       commands.setupCommands(program);
 
       // Set up mock environment variables
-      const testnetOperatorKey = 'mockTestnetOperatorKey';
-      const testnetOperatorId = 'mockTestnetOperatorId';
       process.env.TESTNET_OPERATOR_KEY = testnetOperatorKey;
       process.env.TESTNET_OPERATOR_ID = testnetOperatorId;
       
@@ -66,6 +63,7 @@ describe('setup init command', () => {
         ...baseState,
         testnetOperatorId,
         testnetOperatorKey,
+        accounts: testnetOperatorAccount,
       });
     });
   });

--- a/__tests__/helpers/state.ts
+++ b/__tests__/helpers/state.ts
@@ -134,3 +134,20 @@ export const downloadState: object = {
     [token.tokenId]: token,
   },
 }
+
+export const testnetOperatorKey = '302e020100300506032b6570042204202ef1cb430150535aa15bdcc6609ff2ef4ec843eb35f1d0cc655a4cad2130b796'; // dummy account
+export const testnetOperatorId = '0.0.7699836';
+
+export const testnetOperatorAccount = {
+  "testnet-operator": {
+    accountId: "0.0.7699836",
+    alias: "testnet-operator",
+    evmAddress: "",
+    network: "testnet",
+    privateKey: "302e020100300506032b6570042204202ef1cb430150535aa15bdcc6609ff2ef4ec843eb35f1d0cc655a4cad2130b796",
+    publicKey: "302a300506032b6570032100b5416f8c0c2836904c58082e4e4a4e923db30bcf85aa189b41fa91062eb8e98b",
+    solidityAddress: "0000000000000000000000000000000000757d7c",
+    solidityAddressFull: "0x0000000000000000000000000000000000757d7c",
+    type: "ed25519",
+  }
+};

--- a/src/commands/hbar.ts
+++ b/src/commands/hbar.ts
@@ -36,10 +36,8 @@ export default (program: any) => {
         try {
           const accounts = Object.keys(stateController.getAll().accounts);
           if (accounts.length === 0) {
-            logger.error(
-              'No accounts found to transfer hbar from. Please create an account first.',
-            );
-            process.exit(1);
+            stateUtils.getNetwork()
+            accounts.push('testnet-operator');
           }
           from = await enquirerUtils.createPrompt(
             accounts,

--- a/src/commands/hbar.ts
+++ b/src/commands/hbar.ts
@@ -5,7 +5,7 @@ import dynamicVariablesUtils from '../utils/dynamicVariables';
 import { Logger } from '../utils/logger';
 import hbarUtils from '../utils/hbar';
 
-import type { Command } from '../../types';
+import type { Account, Command } from '../../types';
 
 const logger = Logger.getInstance();
 
@@ -31,16 +31,20 @@ export default (program: any) => {
 
       let to = options.to;
       let from = options.from;
+      const network = stateUtils.getNetwork();
 
       if (!options.from) {
         try {
-          const accounts = Object.keys(stateController.getAll().accounts);
-          if (accounts.length === 0) {
-            stateUtils.getNetwork()
-            accounts.push('testnet-operator');
+          const accounts: Account[] = Object.values(stateController.getAll().accounts);
+          const filteredAccounts = accounts.filter((account) => account.network === network);
+          if (filteredAccounts.length === 0) {
+            logger.error(
+              'No accounts found to transfer hbar from. Please create an account first.',
+            );
+            process.exit(1);
           }
           from = await enquirerUtils.createPrompt(
-            accounts,
+            filteredAccounts.map((account) => account.alias),
             'Choose account to transfer hbar from:',
           );
         } catch (error) {
@@ -51,15 +55,16 @@ export default (program: any) => {
 
       if (!options.to) {
         try {
-          const accounts = Object.keys(stateController.getAll().accounts);
-          if (accounts.length === 0) {
+          const accounts: Account[] = Object.values(stateController.getAll().accounts);
+          const filteredAccounts = accounts.filter((account) => account.network === network);
+          if (filteredAccounts.length === 0) {
             logger.error(
               'No accounts found to transfer hbar from. Please create an account first.',
             );
             process.exit(1);
           }
           to = await enquirerUtils.createPrompt(
-            accounts,
+            filteredAccounts.map((account) => account.alias),
             'Choose account to transfer hbar to:',
           );
         } catch (error) {

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -319,25 +319,55 @@ function findAccountByAlias(inputAlias: string): Account {
 
 /**
  * @description Returns the type of a private key
- * @param keyString Input private key
+ * @param privateKey Input private key
  * @returns {string} key type {ed25519, ecdsa, Unknown key type}
  */
-function getKeyType(keyString: string): string {
+function getKeyType(privateKey: string): string {
   try {
-    PrivateKey.fromStringED25519(keyString);
+    PrivateKey.fromStringED25519(privateKey);
     return 'ed25519';
   } catch (e) {
     // Not an Ed25519 private key
   }
 
   try {
-    PrivateKey.fromStringECDSA(keyString);
+    PrivateKey.fromStringECDSA(privateKey);
     return 'ecdsa';
   } catch (e) {
     // Not an ECDSA private key
   }
 
   return 'Unknown key type';
+}
+
+function getPublicKeyFromPrivateKey(privateKey: string): string {
+  const keyType = getKeyType(privateKey);
+
+  if (keyType === 'ed25519') {
+    return PrivateKey.fromStringED25519(privateKey).publicKey.toString();
+  }
+
+  if (keyType === 'ecdsa') {
+    return PrivateKey.fromStringECDSA(privateKey).publicKey.toString();
+  }
+
+  logger.error('Invalid private key');
+  process.exit(1);
+}
+
+function getPrivateKeyObject(privateKey: string): PrivateKey {
+  const keyType = getKeyType(privateKey);
+
+  if (keyType === 'ed25519') {
+    return PrivateKey.fromStringED25519(privateKey);
+  }
+
+  if (keyType === 'ecdsa') {
+    return PrivateKey.fromStringECDSA(privateKey);
+  }
+
+  logger.error('Invalid private key');
+  process.exit(1);
 }
 
 function generateRandomAlias(): string {
@@ -359,6 +389,8 @@ const accountUtils = {
   getAccountBalance,
   getAccountHbarBalance,
   getKeyType,
+  getPublicKeyFromPrivateKey,
+  getPrivateKeyObject,
   generateRandomAlias,
   clearAddressBook,
   deleteAccount,

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -51,6 +51,12 @@ async function createAccount(
     process.exit(1);
   }
 
+  // Validate alias: Not allowed to use "operator" as an alias or part of an alias
+  if (alias.toLowerCase().includes('operator')) {
+    logger.error('Invalid alias. Alias cannot contain the word "operator".');
+    process.exit(1);
+  }
+
   // Get client from config
   const accounts: Record<string, Account> = stateController.get('accounts');
   const client = stateUtils.getHederaClient();

--- a/src/utils/hbar.ts
+++ b/src/utils/hbar.ts
@@ -1,4 +1,4 @@
-import { PrivateKey, TransferTransaction } from '@hashgraph/sdk';
+import { TransferTransaction } from '@hashgraph/sdk';
 
 import stateUtils from './state';
 import { Logger } from '../utils/logger';
@@ -8,8 +8,15 @@ const logger = Logger.getInstance();
 
 async function transfer(amount: number, from: string, to: string): Promise<void> {
     // Find sender account
-    let fromAccount = stateUtils.getAccountByIdOrAlias(from);
-    let fromId = fromAccount.accountId;
+    let fromAccount, fromId;
+    if (from.toLocaleLowerCase() === "operator") {
+      let operator = stateUtils.getOperator();
+      fromAccount = { privateKey: operator.operatorKey };
+      fromId = operator.operatorId;
+    } else {
+      fromAccount = stateUtils.getAccountByIdOrAlias(from);
+      fromId = fromAccount.accountId;
+    }
   
     // Find receiver account
     let toAccount = stateUtils.getAccountByIdOrAlias(to);

--- a/src/utils/hbar.ts
+++ b/src/utils/hbar.ts
@@ -7,16 +7,15 @@ import signUtils from './sign';
 const logger = Logger.getInstance();
 
 async function transfer(amount: number, from: string, to: string): Promise<void> {
+    if (from === to) {
+      logger.error('Cannot transfer to the same account');
+      process.exit(1);
+    }
+    
     // Find sender account
     let fromAccount, fromId;
-    if (from.toLocaleLowerCase() === "operator") {
-      let operator = stateUtils.getOperator();
-      fromAccount = { privateKey: operator.operatorKey };
-      fromId = operator.operatorId;
-    } else {
-      fromAccount = stateUtils.getAccountByIdOrAlias(from);
-      fromId = fromAccount.accountId;
-    }
+    fromAccount = stateUtils.getAccountByIdOrAlias(from);
+    fromId = fromAccount.accountId;
   
     // Find receiver account
     let toAccount = stateUtils.getAccountByIdOrAlias(to);

--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -1,4 +1,6 @@
+import { AccountId } from '@hashgraph/sdk';
 import stateController from '../state/stateController';
+import accountUtils from './account';
 
 /**
  * @description Setup operator accounts for previewnet, testnet, and mainnet in the state file
@@ -11,7 +13,6 @@ function setupOperatorAccounts(
   previewnetOperatorId: string,
   previewnetOperatorKey: string,
 ): void {
-  console.log(testnetOperatorKey)
   const state = stateController.getAll();
   let newState = { ...state };
   newState.testnetOperatorKey = testnetOperatorKey;
@@ -20,6 +21,60 @@ function setupOperatorAccounts(
   newState.mainnetOperatorId = mainnetOperatorId;
   newState.previewnetOperatorId = previewnetOperatorId;
   newState.previewnetOperatorKey = previewnetOperatorKey;
+
+  if (testnetOperatorId) {
+    const privateKeyObject = accountUtils.getPrivateKeyObject(testnetOperatorKey);
+
+    newState.accounts['testnet-operator'] = {
+      accountId: testnetOperatorId,
+      privateKey: testnetOperatorKey,
+      network: 'testnet',
+      alias: 'testnet-operator',
+      type: privateKeyObject.type.toLowerCase(),
+      publicKey: privateKeyObject.publicKey.toString(),
+      evmAddress: privateKeyObject.type.toLowerCase() === 'ed25519'
+          ? ''
+          : privateKeyObject.publicKey.toEvmAddress(),
+      solidityAddress: `${AccountId.fromString(testnetOperatorId).toSolidityAddress()}`,
+      solidityAddressFull: `0x${AccountId.fromString(testnetOperatorId).toSolidityAddress()}`,
+    };
+  }
+
+  if (previewnetOperatorId) {
+    const privateKeyObject = accountUtils.getPrivateKeyObject(previewnetOperatorKey);
+
+    newState.accounts['preview-operator'] = {
+      accountId: previewnetOperatorId,
+      privateKey: previewnetOperatorKey,
+      network: 'previewnet',
+      alias: 'preview-operator',
+      type: privateKeyObject.type.toLowerCase(),
+      publicKey: privateKeyObject.publicKey.toString(),
+      evmAddress: privateKeyObject.type.toLowerCase() === 'ed25519'
+          ? ''
+          : privateKeyObject.publicKey.toEvmAddress(),
+      solidityAddress: `${AccountId.fromString(previewnetOperatorId).toSolidityAddress()}`,
+      solidityAddressFull: `0x${AccountId.fromString(previewnetOperatorId).toSolidityAddress()}`,
+    };
+  }
+
+  if (mainnetOperatorId) {
+    const privateKeyObject = accountUtils.getPrivateKeyObject(mainnetOperatorKey);
+
+    newState.accounts['mainnet-operator'] = {
+      accountId: mainnetOperatorId,
+      privateKey: mainnetOperatorKey,
+      network: 'mainnet',
+      alias: 'mainnet-operator',
+      type: privateKeyObject.type.toLowerCase(),
+      publicKey: privateKeyObject.publicKey.toString(),
+      evmAddress: privateKeyObject.type.toLowerCase() === 'ed25519'
+          ? ''
+          : privateKeyObject.publicKey.toEvmAddress(),
+      solidityAddress: `${AccountId.fromString(mainnetOperatorId).toSolidityAddress()}`,
+      solidityAddressFull: `0x${AccountId.fromString(mainnetOperatorId).toSolidityAddress()}`,
+    };
+  }
 
   newState.network = 'testnet';
 

--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -24,15 +24,16 @@ function setupOperatorAccounts(
 
   if (testnetOperatorId) {
     const privateKeyObject = accountUtils.getPrivateKeyObject(testnetOperatorKey);
+    const type = accountUtils.getKeyType(testnetOperatorKey);
 
     newState.accounts['testnet-operator'] = {
       accountId: testnetOperatorId,
       privateKey: testnetOperatorKey,
       network: 'testnet',
       alias: 'testnet-operator',
-      type: privateKeyObject.type.toLowerCase(),
-      publicKey: privateKeyObject.publicKey.toString(),
-      evmAddress: privateKeyObject.type.toLowerCase() === 'ed25519'
+      type,
+      publicKey: privateKeyObject.publicKey.toStringDer(),
+      evmAddress: type === 'ed25519'
           ? ''
           : privateKeyObject.publicKey.toEvmAddress(),
       solidityAddress: `${AccountId.fromString(testnetOperatorId).toSolidityAddress()}`,
@@ -42,15 +43,16 @@ function setupOperatorAccounts(
 
   if (previewnetOperatorId) {
     const privateKeyObject = accountUtils.getPrivateKeyObject(previewnetOperatorKey);
+    const type = accountUtils.getKeyType(previewnetOperatorKey);
 
     newState.accounts['preview-operator'] = {
       accountId: previewnetOperatorId,
       privateKey: previewnetOperatorKey,
       network: 'previewnet',
       alias: 'preview-operator',
-      type: privateKeyObject.type.toLowerCase(),
-      publicKey: privateKeyObject.publicKey.toString(),
-      evmAddress: privateKeyObject.type.toLowerCase() === 'ed25519'
+      type,
+      publicKey: privateKeyObject.publicKey.toStringDer(),
+      evmAddress: type === 'ed25519'
           ? ''
           : privateKeyObject.publicKey.toEvmAddress(),
       solidityAddress: `${AccountId.fromString(previewnetOperatorId).toSolidityAddress()}`,
@@ -60,15 +62,16 @@ function setupOperatorAccounts(
 
   if (mainnetOperatorId) {
     const privateKeyObject = accountUtils.getPrivateKeyObject(mainnetOperatorKey);
+    const type = accountUtils.getKeyType(mainnetOperatorKey);
 
     newState.accounts['mainnet-operator'] = {
       accountId: mainnetOperatorId,
       privateKey: mainnetOperatorKey,
       network: 'mainnet',
       alias: 'mainnet-operator',
-      type: privateKeyObject.type.toLowerCase(),
-      publicKey: privateKeyObject.publicKey.toString(),
-      evmAddress: privateKeyObject.type.toLowerCase() === 'ed25519'
+      type,
+      publicKey: privateKeyObject.publicKey.toStringDer(),
+      evmAddress: type === 'ed25519'
           ? ''
           : privateKeyObject.publicKey.toEvmAddress(),
       solidityAddress: `${AccountId.fromString(mainnetOperatorId).toSolidityAddress()}`,

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -75,6 +75,39 @@ function getNetwork() {
   return state.network;
 }
 
+function getOperator(): { operatorId: string; operatorKey: string } {
+  const state = stateController.getAll();
+  let operatorId, operatorKey;
+
+  switch (state.network) {
+    case 'mainnet':
+      operatorId = state.mainnetOperatorId;
+      operatorKey = state.mainnetOperatorKey;
+      break;
+    case 'testnet':
+      operatorId = state.testnetOperatorId;
+      operatorKey = state.testnetOperatorKey;
+      break;
+    case 'previewnet':
+      operatorId = state.previewnetOperatorId;
+      operatorKey = state.previewnetOperatorKey;
+      break;
+    default:
+      logger.error('Invalid network name');
+      process.exit(1);
+  }
+
+  if (operatorId === '' || operatorKey === '') {
+    logger.error(`operator key and ID not set for ${state.network}`);
+    process.exit(1);
+  }
+
+  return {
+    operatorId,
+    operatorKey,
+  };
+}
+
 function switchNetwork(name: string) {
   if (!['mainnet', 'testnet', 'previewnet'].includes(name)) {
     logger.error(
@@ -295,6 +328,7 @@ function addTokens(importedTokens: Token[], merge: boolean) {
 const stateUtils = {
   getMirrorNodeURL,
   getHederaClient,
+  getOperator,
   recordCommand,
   switchNetwork,
   getNetwork,


### PR DESCRIPTION
**Description**:
Add ability to transfer Hbar from operator accounts (testnet, previewnet, mainnet). 
Addition: When using `setup init`, the operator accounts that have been set in the .env file will also be added as proper account entities in the `state.accounts`. 

**Closes**: #203 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
