### PR TITLE
Add E2E testing - Closes #205

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,18 +478,19 @@ backup restore
 
 **1. Creating Backup:**
 
-This command creates a backup of the `state.json` file. The backup file is named using a timestamp for easy identification and recovery. The format is: `state.backup.<timestamp>.json`. The backup is stored in the same `dist/state` directory as `state.json`.
+This command creates a backup of the `state.json` file. The backup file is named using a timestamp for easy identification and recovery. The format is: `state.backup.<timestamp>.json`. The backup is stored in the same `dist/state` directory as `state.json`. It's possible to provide a custom name for the backup file: `state.backup.<name>.json`.
 
 ```sh
-hcli backup create [--accounts] [--safe]
+hcli backup create [--name <name>] [--accounts] [--safe]
 
 // Example
 hcli backup create --accounts --safe
 hcli backup create --safe
-hcli backup create
+hcli backup create --name myBackup
 ```
 
 Flags:
+- **Name:** (optional) Filename of the backup file. Defaults to `state.backup.<timestamp>.json`.
 - **Accounts:** (optional) Creates a backup of the accounts section of the state. The backup file is named `accounts.backup.<timestamp>.json`.
 - **Safe:** (optional) Removes private information from the backup like token keys, account keys, and operator key/ID. It does not remove the private keys in scripts' commands.
 

--- a/__tests__/e2e/flow1.test.ts
+++ b/__tests__/e2e/flow1.test.ts
@@ -1,0 +1,117 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { baseState } from "../helpers/state";
+import { program } from 'commander';
+import commands from "../../src/commands";
+import stateController from "../../src/state/stateController";
+import api from "../../src/api";
+
+/**
+ * E2E testing flow:
+ * - Setup init
+ * - Switch to testnet
+ * - Create a new account with specific balance, type, and network and verify it is created
+ * - Transfer part of the balance back to the operator account and verify the balance is correct
+ * - Create a backup of the state file and verify it is created
+ * - Delete the account and verify it is deleted
+ * - Restore the state file from backup and verify the account and operator details are restored
+ */
+describe("hbar transfer command", () => {
+  beforeEach(() => {
+    stateController.saveState(baseState); // reset state to base state for each test
+  });
+
+  describe("Flow 1", () => {
+    test("✅ flow 1", async () => {
+        // Arrange: Setup init
+        commands.setupCommands(program);
+
+        // Act
+        await program.parseAsync(["node", "hedera-cli.ts", "setup", "init"]);
+
+        // Assert
+        const accounts = stateController.get('accounts');
+        expect(accounts['testnet-operator']).toBeDefined();
+
+        // Arrange: Change network to testnet
+        commands.networkCommands(program);
+
+        // Act
+        program.parse(["node", "hedera-cli.ts", "network", "use", "testnet"]);
+
+        // Assert
+        const network = stateController.get('network');
+        expect(network).toEqual('testnet');
+
+        // Arrange: Create a new account with specific balance, type, and network and verify it is created
+        commands.accountCommands(program);
+        commands.waitCommands(program);
+        const accountAlias = "greg";
+
+        // Act
+        await program.parseAsync(["node", "hedera-cli.ts", "account", "create", "-a", accountAlias, "-t", "ECdsA", "--auto-associations", "1"]);
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        
+        // Assert
+        let state = stateController.get('accounts');
+        expect(state[accountAlias]).toBeDefined();
+        expect(state[accountAlias].type).toEqual("ECDSA");
+        
+        let data = await api.account.getAccountInfo(state[accountAlias].accountId);
+        expect(data.data.balance.balance).toEqual(10000); // default value if no balance is specified
+
+        // Arrange: Transfer part of the balance back to the operator account and verify the balance is correct
+        commands.hbarCommands(program);
+        const transferAmount = 0.00001;
+
+        // Act
+        await program.parseAsync(["node", "hedera-cli.ts", "hbar", "transfer", "-b", transferAmount.toString(), "-f", accountAlias, "-t", "testnet-operator"]);
+        await new Promise(resolve => setTimeout(resolve, 5000));
+
+        // Assert
+        data = await api.account.getAccountInfo(state[accountAlias].accountId);
+        expect(data.data.balance.balance).toEqual(9000);
+
+        // Arrange: Create a backup of the state file and verify it is created
+        commands.backupCommands(program);
+        const backupName = "flow1";
+
+        // Act
+        program.parse(["node", "hedera-cli.ts", "backup", "create", "--name", backupName]);
+
+        // Assert
+        let files = fs.readdirSync(path.join(__dirname, '../..', 'src', 'state'));
+        expect(files).toContain(`state.backup.${backupName}.json`);
+
+        // Arrange: Delete the account and verify it is deleted in state
+        commands.accountCommands(program);
+
+        // Act
+        program.parse(["node", "hedera-cli.ts", "account", "delete", "-a", accountAlias]);
+
+        // Assert
+        state = stateController.get('accounts');
+        expect(state[accountAlias]).toBeUndefined();
+
+        // Arrange: Restore the state file from backup and verify the account and operator details are restored
+        commands.backupCommands(program);
+
+        // Act
+        program.parse(["node", "hedera-cli.ts", "backup", "restore", "-f", `state.backup.${backupName}.json`]);
+
+        // Assert
+        state = stateController.get('accounts');
+        expect(state[accountAlias]).toBeDefined();
+
+        // Cleanup
+        files = fs.readdirSync(path.join(__dirname, '../..', 'src', 'state'));
+        const pattern = /^state\.backup\.[a-zA-Z0-9]+\.json$/;
+        const backups = files.filter((file) => pattern.test(file));
+
+        for (const backup of backups) {
+          fs.unlinkSync(path.join(__dirname, '../..', 'src', 'state', backup));
+        }
+    });
+  });
+});

--- a/__tests__/e2e/flow1.test.ts
+++ b/__tests__/e2e/flow1.test.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { baseState } from "../helpers/state";
+import { baseState } from '../helpers/state';
 import { program } from 'commander';
-import commands from "../../src/commands";
-import stateController from "../../src/state/stateController";
-import api from "../../src/api";
+import commands from '../../src/commands';
+import stateController from '../../src/state/stateController';
+import api from '../../src/api';
 
 /**
  * E2E testing flow:
@@ -17,101 +17,142 @@ import api from "../../src/api";
  * - Delete the account and verify it is deleted
  * - Restore the state file from backup and verify the account and operator details are restored
  */
-describe("hbar transfer command", () => {
+describe('End to end: Flow 1', () => {
   beforeEach(() => {
     stateController.saveState(baseState); // reset state to base state for each test
   });
 
-  describe("Flow 1", () => {
-    test("✅ flow 1", async () => {
-        // Arrange: Setup init
-        commands.setupCommands(program);
+  test('✅ Flow 1', async () => {
+    // Arrange: Setup init
+    commands.setupCommands(program);
 
-        // Act
-        await program.parseAsync(["node", "hedera-cli.ts", "setup", "init"]);
+    // Act
+    await program.parseAsync(['node', 'hedera-cli.ts', 'setup', 'init']);
 
-        // Assert
-        const accounts = stateController.get('accounts');
-        expect(accounts['testnet-operator']).toBeDefined();
+    // Assert
+    const accounts = stateController.get('accounts');
+    expect(accounts['testnet-operator']).toBeDefined();
 
-        // Arrange: Change network to testnet
-        commands.networkCommands(program);
+    // Arrange: Change network to testnet
+    commands.networkCommands(program);
 
-        // Act
-        program.parse(["node", "hedera-cli.ts", "network", "use", "testnet"]);
+    // Act
+    program.parse(['node', 'hedera-cli.ts', 'network', 'use', 'testnet']);
 
-        // Assert
-        const network = stateController.get('network');
-        expect(network).toEqual('testnet');
+    // Assert
+    const network = stateController.get('network');
+    expect(network).toEqual('testnet');
 
-        // Arrange: Create a new account with specific balance, type, and network and verify it is created
-        commands.accountCommands(program);
-        commands.waitCommands(program);
-        const accountAlias = "greg";
+    // Arrange: Create a new account with specific balance, type, and network and verify it is created
+    commands.accountCommands(program);
+    commands.waitCommands(program);
+    const accountAlias = 'greg';
 
-        // Act
-        await program.parseAsync(["node", "hedera-cli.ts", "account", "create", "-a", accountAlias, "-t", "ECdsA", "--auto-associations", "1"]);
-        await new Promise(resolve => setTimeout(resolve, 5000));
-        
-        // Assert
-        let state = stateController.get('accounts');
-        expect(state[accountAlias]).toBeDefined();
-        expect(state[accountAlias].type).toEqual("ECDSA");
-        
-        let data = await api.account.getAccountInfo(state[accountAlias].accountId);
-        expect(data.data.balance.balance).toEqual(10000); // default value if no balance is specified
+    // Act
+    await program.parseAsync([
+      'node',
+      'hedera-cli.ts',
+      'account',
+      'create',
+      '-a',
+      accountAlias,
+      '-t',
+      'ECdsA',
+      '--auto-associations',
+      '1',
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 5000));
 
-        // Arrange: Transfer part of the balance back to the operator account and verify the balance is correct
-        commands.hbarCommands(program);
-        const transferAmount = 0.00001;
+    // Assert
+    let state = stateController.get('accounts');
+    expect(state[accountAlias]).toBeDefined();
+    expect(state[accountAlias].type).toEqual('ECDSA');
 
-        // Act
-        await program.parseAsync(["node", "hedera-cli.ts", "hbar", "transfer", "-b", transferAmount.toString(), "-f", accountAlias, "-t", "testnet-operator"]);
-        await new Promise(resolve => setTimeout(resolve, 5000));
+    let data = await api.account.getAccountInfo(state[accountAlias].accountId);
+    expect(data.data.balance.balance).toEqual(10000); // default value if no balance is specified
 
-        // Assert
-        data = await api.account.getAccountInfo(state[accountAlias].accountId);
-        expect(data.data.balance.balance).toEqual(9000);
+    // Arrange: Transfer part of the balance back to the operator account and verify the balance is correct
+    commands.hbarCommands(program);
+    const transferAmount = 0.00001;
 
-        // Arrange: Create a backup of the state file and verify it is created
-        commands.backupCommands(program);
-        const backupName = "flow1";
+    // Act
+    await program.parseAsync([
+      'node',
+      'hedera-cli.ts',
+      'hbar',
+      'transfer',
+      '-b',
+      transferAmount.toString(),
+      '-f',
+      accountAlias,
+      '-t',
+      'testnet-operator',
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 5000));
 
-        // Act
-        program.parse(["node", "hedera-cli.ts", "backup", "create", "--name", backupName]);
+    // Assert
+    data = await api.account.getAccountInfo(state[accountAlias].accountId);
+    expect(data.data.balance.balance).toEqual(9000);
 
-        // Assert
-        let files = fs.readdirSync(path.join(__dirname, '../..', 'src', 'state'));
-        expect(files).toContain(`state.backup.${backupName}.json`);
+    // Arrange: Create a backup of the state file and verify it is created
+    commands.backupCommands(program);
+    const backupName = 'flow1';
 
-        // Arrange: Delete the account and verify it is deleted in state
-        commands.accountCommands(program);
+    // Act
+    program.parse([
+      'node',
+      'hedera-cli.ts',
+      'backup',
+      'create',
+      '--name',
+      backupName,
+    ]);
 
-        // Act
-        program.parse(["node", "hedera-cli.ts", "account", "delete", "-a", accountAlias]);
+    // Assert
+    let files = fs.readdirSync(path.join(__dirname, '../..', 'src', 'state'));
+    expect(files).toContain(`state.backup.${backupName}.json`);
 
-        // Assert
-        state = stateController.get('accounts');
-        expect(state[accountAlias]).toBeUndefined();
+    // Arrange: Delete the account and verify it is deleted in state
+    commands.accountCommands(program);
 
-        // Arrange: Restore the state file from backup and verify the account and operator details are restored
-        commands.backupCommands(program);
+    // Act
+    program.parse([
+      'node',
+      'hedera-cli.ts',
+      'account',
+      'delete',
+      '-a',
+      accountAlias,
+    ]);
 
-        // Act
-        program.parse(["node", "hedera-cli.ts", "backup", "restore", "-f", `state.backup.${backupName}.json`]);
+    // Assert
+    state = stateController.get('accounts');
+    expect(state[accountAlias]).toBeUndefined();
 
-        // Assert
-        state = stateController.get('accounts');
-        expect(state[accountAlias]).toBeDefined();
+    // Arrange: Restore the state file from backup and verify the account and operator details are restored
+    commands.backupCommands(program);
 
-        // Cleanup
-        files = fs.readdirSync(path.join(__dirname, '../..', 'src', 'state'));
-        const pattern = /^state\.backup\.[a-zA-Z0-9]+\.json$/;
-        const backups = files.filter((file) => pattern.test(file));
+    // Act
+    program.parse([
+      'node',
+      'hedera-cli.ts',
+      'backup',
+      'restore',
+      '-f',
+      `state.backup.${backupName}.json`,
+    ]);
 
-        for (const backup of backups) {
-          fs.unlinkSync(path.join(__dirname, '../..', 'src', 'state', backup));
-        }
-    });
+    // Assert
+    state = stateController.get('accounts');
+    expect(state[accountAlias]).toBeDefined();
+
+    // Cleanup
+    files = fs.readdirSync(path.join(__dirname, '../..', 'src', 'state'));
+    const pattern = /^state\.backup\.[a-zA-Z0-9]+\.json$/;
+    const backups = files.filter((file) => pattern.test(file));
+
+    for (const backup of backups) {
+      fs.unlinkSync(path.join(__dirname, '../..', 'src', 'state', backup));
+    }
   });
 });

--- a/__tests__/e2e/scripts.test.ts
+++ b/__tests__/e2e/scripts.test.ts
@@ -5,7 +5,6 @@ import { baseState } from '../helpers/state';
 import { program } from 'commander';
 import commands from '../../src/commands';
 import stateController from '../../src/state/stateController';
-import api from '../../src/api';
 
 /**
  * E2E testing flow for scripts:
@@ -15,7 +14,7 @@ import api from '../../src/api';
  */
 describe('End to end: Script features', () => {
   beforeEach(() => {
-    //stateController.saveState(baseState); // reset state to base state for each test
+    stateController.saveState(baseState); // reset state to base state for each test
   });
 
   test('✅ Script features', async () => {

--- a/__tests__/e2e/scripts.test.ts
+++ b/__tests__/e2e/scripts.test.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { baseState } from '../helpers/state';
+import { program } from 'commander';
+import commands from '../../src/commands';
+import stateController from '../../src/state/stateController';
+import api from '../../src/api';
+
+/**
+ * E2E testing flow for scripts:
+ * - Download a script from the internet
+ * - Load and execute the script (list all scripts and spy on logger function)
+ * - Delete script and verify it is deleted in state file
+ */
+describe('End to end: Script features', () => {
+  beforeEach(() => {
+    //stateController.saveState(baseState); // reset state to base state for each test
+  });
+
+  test('✅ Script features', async () => {
+    // Arrange: Setup init
+    commands.setupCommands(program);
+
+    // Act
+    await program.parseAsync(['node', 'hedera-cli.ts', 'setup', 'init']);
+
+    // Assert
+    let accounts = stateController.get('accounts');
+    expect(accounts['testnet-operator']).toBeDefined();
+
+    // Arrange: Download a script from the internet
+    commands.stateCommands(program);
+    const scriptURL = 'https://raw.githubusercontent.com/hashgraph/hedera-cli/main/src/commands/script/examples.json';
+
+    // Act
+    await program.parseAsync([
+      'node',
+      'hedera-cli.ts',
+      'state',
+      'download',
+      '--url',
+      scriptURL,
+    ]);
+
+    // Assert
+    let scripts = stateController.get('scripts');
+    expect(scripts['script-token']).toBeDefined();
+    expect(scripts['script-account-create']).toBeDefined();
+
+    // Arrange: Load and execute the script (list all scripts and spy on logger function)
+    commands.scriptCommands(program);
+
+    // Act
+    await program.parseAsync([
+        'node',
+        'hedera-cli.ts',
+        'script',
+        'load',
+        '-n',
+        'account-create-simple',
+    ]);
+
+    // Assert
+    const distStatePath = path.join(__dirname, '..', '..', 'dist', 'state', 'state.json'); // read state from dist/state/state.json because script load uses dist/ logic
+    const distState = await fs.readFileSync(distStatePath, 'utf8')
+    expect(Object.keys((JSON.parse(distState)).accounts).length).toBe(1); // 1 random account created
+
+    // Reset state to base state
+    await fs.writeFileSync(distStatePath, JSON.stringify(baseState, null, 2), 'utf8');
+
+    // Arrange: Delete script and verify it is deleted in state file
+    // Act
+    program.parse(['node', 'hedera-cli.ts', 'script', 'delete', '-n', 'account-create-simple']);
+
+    // Assert
+    scripts = stateController.get('scripts');
+    expect(scripts['script-account-create-simple']).toBeUndefined();
+    expect(scripts['script-account-create']).toBeDefined();
+  });
+});

--- a/__tests__/e2e/tokens.test.ts
+++ b/__tests__/e2e/tokens.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { baseState } from '../helpers/state';
+import { program } from 'commander';
+import commands from '../../src/commands';
+import stateController from '../../src/state/stateController';
+import { Token } from '../../types';
+import api from '../../src/api';
+
+/**
+ * E2E testing flow for tokens:
+ * - Create 3 accounts
+ * - Create a token (account 1 is the treasury and account 2 is the admin key)
+ * - Associate the token with account 3
+ * - Transfer 1 unit of token from treasury to account 3
+ * - Verify balance by looking up the token balance of account 3 via API
+ */
+describe('End to end: Token features', () => {
+  beforeEach(() => {
+    stateController.saveState(baseState); // reset state to base state for each test
+  });
+
+  test('✅ Token features', async () => {
+    // Arrange: Setup init
+    commands.setupCommands(program);
+
+    // Act
+    await program.parseAsync(['node', 'hedera-cli.ts', 'setup', 'init']);
+
+    // Assert
+    let accounts = stateController.get('accounts');
+    expect(accounts['testnet-operator']).toBeDefined();
+
+    // Arrange: Create 3 accounts
+    commands.accountCommands(program);
+    const accountAliasTreasury = 'treasury';
+    const accountAliasAdmin = 'admin';
+    const accountAliasUser = 'user';
+
+    // Act
+    await program.parseAsync(['node', 'hedera-cli.ts', 'account', 'create', '-a', accountAliasTreasury, '-b', '300000000']);
+    await program.parseAsync(['node', 'hedera-cli.ts', 'account', 'create', '-a', accountAliasAdmin, '-b', '300000000']);
+    await program.parseAsync(['node', 'hedera-cli.ts', 'account', 'create', '-a', accountAliasUser, '-b', '300000000']);
+
+    // Assert
+    accounts = stateController.get('accounts');
+    expect(accounts[accountAliasTreasury]).toBeDefined();
+    expect(accounts[accountAliasAdmin]).toBeDefined();
+    expect(accounts[accountAliasUser]).toBeDefined();
+
+    // Arrange: Create a token (account 1 is the treasury and account 2 is the admin key)
+    commands.tokenCommands(program);
+    const tokenName = 'test-token';
+
+    // Act
+    await program.parseAsync(['node', 'hedera-cli.ts', 'token', 'create', '-a', accounts[accountAliasAdmin].privateKey, '-t', accounts[accountAliasTreasury].accountId, '-k', accounts[accountAliasTreasury].privateKey, '-n', tokenName, '-s', 'TT', '-i', '1000', '-d', '2', '--supply-type', 'infinite']);
+
+    // Assert
+    let tokens = stateController.get('tokens') as Token[];
+    let token = Object.values(tokens).find((token: Token) => token.name === tokenName);
+    expect(token).toBeDefined();
+
+
+    // TypeScript still sees `token` as possibly undefined. You need to assert it's not.
+    if (!token) {
+      throw new Error("Token not found");
+    }
+
+    // Arrange: Associate the token with account 3 (user)
+    // Act
+    await program.parseAsync(['node', 'hedera-cli.ts', 'token', 'associate', '--account-id', accounts[accountAliasUser].accountId, '-t', token.tokenId]);
+
+    // Assert
+    tokens = stateController.get('tokens') as Token[];
+    token = Object.values(tokens).find((token: Token) => token.name === tokenName);
+    expect(token?.associations).toEqual([{ accountId: accounts[accountAliasUser].accountId, alias: accountAliasUser }]);
+
+    if (!token) {
+      throw new Error("Token not found");
+    }
+
+    // Arrange: Transfer 1 unit of token from treasury to account 3 (user)
+    // Act
+    await program.parseAsync(['node', 'hedera-cli.ts', 'token', 'transfer', '-t', token.tokenId, '-b', '1', '--from', accountAliasTreasury, '--to', accountAliasUser]);
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Assert
+    const data = await api.token.getTokenBalance(token.tokenId, accounts[accountAliasUser].accountId);
+    expect(data.data.balances).toEqual([{ account: accounts[accountAliasUser].accountId, balance: 1 }]);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testTimeout: 40000,
   testPathIgnorePatterns: [
     "<rootDir>/__tests__/helpers/"
   ]

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -7,10 +7,9 @@ const logger = Logger.getInstance();
 
 /**
  * API functions:
- * - getAccountBalance(accountId): Get the balance of an account
+ * - getAccountInfo(accountId): Get the info of an account
  */
-
-async function getAccountBalance(
+async function getAccountInfo(
   accountId: string,
 ): Promise<APIResponse<AccountResponse>> {
   try {
@@ -28,5 +27,5 @@ async function getAccountBalance(
 }
 
 export default {
-  getAccountBalance,
+  getAccountInfo,
 };

--- a/src/commands/script/examples.json
+++ b/src/commands/script/examples.json
@@ -20,9 +20,19 @@
         "commands": [
           "network use testnet",
           "account create -a random -b 10000000 --type ecdsa --args privateKey,privKeyAcc1 --args alias,aliasAcc1 --args accountId,idAcc1",
-          "wait 3",
+          "wait 5",
           "account balance --account-id-or-alias {{idAcc1}} --only-hbar"
         ]
+      },
+      "script-account-create-simple": {
+        "name": "account-create-simple",
+        "creation": 1706620441200,
+        "commands": [
+          "network use testnet",
+          "account create -a random -b 10000000 --type ecdsa --args privateKey,privKeyAcc1 --args alias,aliasAcc1 --args accountId,idAcc1",
+          "wait 5"
+        ],
+        "args": {}
       }
     }
   }

--- a/src/commands/wait.ts
+++ b/src/commands/wait.ts
@@ -16,13 +16,12 @@ export default (program: any) => {
       stateUtils.recordCommand(command);
     })
     .description('Wait for a specified number of seconds')
-    .action((seconds: string) => {
+    .action(async (seconds: string) => {
       logger.verbose(`Waiting for ${seconds} seconds`);
-      wait(seconds);
+      await wait(Number(seconds));
     });
 };
 
-function wait(seconds: string) {
-  const ms = Number(seconds) * 1000;
-  setTimeout(() => {}, ms);
+async function wait(seconds: number) {
+  await new Promise((resolve) => setTimeout(resolve, (seconds * 1000)));
 }

--- a/src/state/state.json
+++ b/src/state/state.json
@@ -28,39 +28,61 @@
       "evmAddress": "f2ad3082c76a6318dd2c8e281bd2e64dca6d01df",
       "solidityAddress": "00000000000000000000000000000000000008b1",
       "solidityAddressFull": "0x00000000000000000000000000000000000008b1"
-    }
-  },
-  "tokens": {},
-  "scripts": {
-    "script-token": {
-      "name": "token",
-      "creation": 1706620441178,
-      "commands": [
-        "network use testnet",
-        "account create -a random --args privateKey,privKeyAcc1 --args alias,aliasAcc1 --args accountId,idAcc1",
-        "account create -a random --args privateKey,privKeyAcc2 --args alias,aliasAcc2 --args accountId,idAcc2",
-        "account create -a random --args privateKey,privKeyAcc3 --args alias,aliasAcc3 --args accountId,idAcc3",
-        "token create -n mytoken -s MTK -d 2 -i 1000 --supply-type infinite -a {{privKeyAcc1}} -t {{idAcc2}} -k {{privKeyAcc2}} --args tokenId,tokenId",
-        "token associate --account-id {{idAcc3}} --token-id {{tokenId}}",
-        "token transfer -t {{tokenId}} -b 1 --from {{aliasAcc2}} --to {{aliasAcc3}}",
-        "wait 5",
-        "account balance --account-id-or-alias {{aliasAcc3}} --token-id {{tokenId}}",
-        "state view --token-id {{tokenId}}"
-      ],
-      "args": {}
     },
-    "script-account-create": {
-      "name": "account-create",
-      "creation": 1706620441199,
-      "commands": [
-        "network use testnet",
-        "account create -a random -b 10000000 --type ecdsa --args privateKey,privKeyAcc1 --args alias,aliasAcc1 --args accountId,idAcc1",
-        "wait 5",
-        "account balance --account-id-or-alias {{idAcc1}} --only-hbar"
-      ],
-      "args": {}
+    "treasury": {
+      "network": "testnet",
+      "alias": "treasury",
+      "accountId": "0.0.7747457",
+      "type": "ED25519",
+      "publicKey": "302a300506032b657003210016d04337d9ac46e7afc82fc3cd623f962ced60b8d612be08dfef7c61ebb96ae9",
+      "evmAddress": "",
+      "solidityAddress": "0000000000000000000000000000000000763781",
+      "solidityAddressFull": "0x0000000000000000000000000000000000763781",
+      "privateKey": "302e020100300506032b6570042204208aafa964c75a6dfe68b6d500c31997407fe1bf91d7a8a28603b24f66dd06640d"
+    },
+    "admin": {
+      "network": "testnet",
+      "alias": "admin",
+      "accountId": "0.0.7747458",
+      "type": "ED25519",
+      "publicKey": "302a300506032b65700321007b387a56e8f93f0c48d63f82dc1aaf6d0f3bd17ac49f79f360d30bde4cb2d95b",
+      "evmAddress": "",
+      "solidityAddress": "0000000000000000000000000000000000763782",
+      "solidityAddressFull": "0x0000000000000000000000000000000000763782",
+      "privateKey": "302e020100300506032b65700422042092402c13740de6e0d40f75872cea5037c1aadc63c256a83ffbc59be0dd890031"
+    },
+    "user": {
+      "network": "testnet",
+      "alias": "user",
+      "accountId": "0.0.7747460",
+      "type": "ED25519",
+      "publicKey": "302a300506032b65700321008bb3e039596242670b639d37c46fa4f15a0791abd5637a83858c921c847db52e",
+      "evmAddress": "",
+      "solidityAddress": "0000000000000000000000000000000000763784",
+      "solidityAddressFull": "0x0000000000000000000000000000000000763784",
+      "privateKey": "302e020100300506032b65700422042011bdfe3acc1975aeb3f99e52f75b128086b7e1a2bc4c88ca22ebff4a38c39e65"
     }
   },
+  "tokens": {
+    "0.0.7747461": {
+      "tokenId": "0.0.7747461",
+      "associations": [
+        {
+          "alias": "user",
+          "accountId": "0.0.7747460"
+        }
+      ],
+      "name": "test-token",
+      "symbol": "TT",
+      "treasuryId": "0.0.7747457",
+      "treasuryKey": "302e020100300506032b6570042204208aafa964c75a6dfe68b6d500c31997407fe1bf91d7a8a28603b24f66dd06640d",
+      "decimals": 2,
+      "initialSupply": 1000,
+      "adminKey": "302e020100300506032b65700422042092402c13740de6e0d40f75872cea5037c1aadc63c256a83ffbc59be0dd890031",
+      "network": "testnet"
+    }
+  },
+  "scripts": {},
   "previewnetOperatorId": "0.0.2225",
   "previewnetOperatorKey": "3030020100300706052b8104000a042204208d7eea780354f14dc9a3ef6d97daf9966051dc8fc44cbb533e32111f7058494b",
   "testnetOperatorKey": "302e020100300506032b65700422042087592ee314bd0f42c4cf9f82b494481a2bb77bab0dc4454eedfe00f60168646f",

--- a/src/state/state.json
+++ b/src/state/state.json
@@ -28,21 +28,39 @@
       "evmAddress": "f2ad3082c76a6318dd2c8e281bd2e64dca6d01df",
       "solidityAddress": "00000000000000000000000000000000000008b1",
       "solidityAddressFull": "0x00000000000000000000000000000000000008b1"
-    },
-    "greg": {
-      "network": "testnet",
-      "alias": "greg",
-      "accountId": "0.0.7746572",
-      "type": "ECDSA",
-      "publicKey": "302d300706052b8104000a03220003ab945f94e817b6590efa07978a60c301216380c3401adb70677d829a0017d598",
-      "evmAddress": "561d1aa339256e66b84aed631b5e179482230185",
-      "solidityAddress": "000000000000000000000000000000000076340c",
-      "solidityAddressFull": "0x000000000000000000000000000000000076340c",
-      "privateKey": "3030020100300706052b8104000a04220420901393474f2650518f9fd91d1a094879b5d31d48ddea39c30b8b08f3d01d6678"
     }
   },
   "tokens": {},
-  "scripts": {},
+  "scripts": {
+    "script-token": {
+      "name": "token",
+      "creation": 1706620441178,
+      "commands": [
+        "network use testnet",
+        "account create -a random --args privateKey,privKeyAcc1 --args alias,aliasAcc1 --args accountId,idAcc1",
+        "account create -a random --args privateKey,privKeyAcc2 --args alias,aliasAcc2 --args accountId,idAcc2",
+        "account create -a random --args privateKey,privKeyAcc3 --args alias,aliasAcc3 --args accountId,idAcc3",
+        "token create -n mytoken -s MTK -d 2 -i 1000 --supply-type infinite -a {{privKeyAcc1}} -t {{idAcc2}} -k {{privKeyAcc2}} --args tokenId,tokenId",
+        "token associate --account-id {{idAcc3}} --token-id {{tokenId}}",
+        "token transfer -t {{tokenId}} -b 1 --from {{aliasAcc2}} --to {{aliasAcc3}}",
+        "wait 5",
+        "account balance --account-id-or-alias {{aliasAcc3}} --token-id {{tokenId}}",
+        "state view --token-id {{tokenId}}"
+      ],
+      "args": {}
+    },
+    "script-account-create": {
+      "name": "account-create",
+      "creation": 1706620441199,
+      "commands": [
+        "network use testnet",
+        "account create -a random -b 10000000 --type ecdsa --args privateKey,privKeyAcc1 --args alias,aliasAcc1 --args accountId,idAcc1",
+        "wait 5",
+        "account balance --account-id-or-alias {{idAcc1}} --only-hbar"
+      ],
+      "args": {}
+    }
+  },
   "previewnetOperatorId": "0.0.2225",
   "previewnetOperatorKey": "3030020100300706052b8104000a042204208d7eea780354f14dc9a3ef6d97daf9966051dc8fc44cbb533e32111f7058494b",
   "testnetOperatorKey": "302e020100300506032b65700422042087592ee314bd0f42c4cf9f82b494481a2bb77bab0dc4454eedfe00f60168646f",

--- a/src/state/state.json
+++ b/src/state/state.json
@@ -2,28 +2,51 @@
   "network": "testnet",
   "mirrorNodeTestnet": "https://testnet.mirrornode.hedera.com/api/v1",
   "mirrorNodeMainnet": "https://mainnet.mirrornode.hedera.com/api/v1",
-  "testnetOperatorKey": "302e020100300506032b65700422042087592ee314bd0f42c4cf9f82b494481a2bb77bab0dc4454eedfe00f60168646f",
-  "testnetOperatorId": "0.0.458179",
-  "previewnetOperatorId": "",
-  "previewnetOperatorKey": "",
-  "mainnetOperatorKey": "",
-  "mainnetOperatorId": "",
   "recording": 0,
   "recordingScriptName": "",
   "scriptExecution": 0,
   "scriptExecutionName": "",
-  "accounts": {},
-  "scripts": {
-    "script-init": {
-      "name": "init",
-      "commands": [
-        "network use testnet",
-        "account create -a alice -b 1000000000 --type ecdsa",
-        "account create -a bob -b 1000000000 --type ecdsa",
-        "account create -a clarice -b 1000000000 --type ecdsa",
-        "state download --url https://raw.githubusercontent.com/hashgraph/hedera-cli/main/src/commands/script/examples.json --merge"
-      ]
+  "accounts": {
+    "testnet-operator": {
+      "accountId": "0.0.458179",
+      "privateKey": "302e020100300506032b65700422042087592ee314bd0f42c4cf9f82b494481a2bb77bab0dc4454eedfe00f60168646f",
+      "network": "testnet",
+      "alias": "testnet-operator",
+      "type": "ed25519",
+      "publicKey": "302a300506032b6570032100f2f4fc538b9b2fd8ce2dba228b109e534d198c40a09df8cbcb96446f7884d27c",
+      "evmAddress": "",
+      "solidityAddress": "000000000000000000000000000000000006fdc3",
+      "solidityAddressFull": "0x000000000000000000000000000000000006fdc3"
+    },
+    "preview-operator": {
+      "accountId": "0.0.2225",
+      "privateKey": "3030020100300706052b8104000a042204208d7eea780354f14dc9a3ef6d97daf9966051dc8fc44cbb533e32111f7058494b",
+      "network": "previewnet",
+      "alias": "preview-operator",
+      "type": "ecdsa",
+      "publicKey": "302d300706052b8104000a0322000393be0a979355e2249c813dceea855dbe91fa6c914e3e3dcb752b4f3444a047d1",
+      "evmAddress": "f2ad3082c76a6318dd2c8e281bd2e64dca6d01df",
+      "solidityAddress": "00000000000000000000000000000000000008b1",
+      "solidityAddressFull": "0x00000000000000000000000000000000000008b1"
+    },
+    "greg": {
+      "network": "testnet",
+      "alias": "greg",
+      "accountId": "0.0.7746572",
+      "type": "ECDSA",
+      "publicKey": "302d300706052b8104000a03220003ab945f94e817b6590efa07978a60c301216380c3401adb70677d829a0017d598",
+      "evmAddress": "561d1aa339256e66b84aed631b5e179482230185",
+      "solidityAddress": "000000000000000000000000000000000076340c",
+      "solidityAddressFull": "0x000000000000000000000000000000000076340c",
+      "privateKey": "3030020100300706052b8104000a04220420901393474f2650518f9fd91d1a094879b5d31d48ddea39c30b8b08f3d01d6678"
     }
   },
-  "tokens": {}
+  "tokens": {},
+  "scripts": {},
+  "previewnetOperatorId": "0.0.2225",
+  "previewnetOperatorKey": "3030020100300706052b8104000a042204208d7eea780354f14dc9a3ef6d97daf9966051dc8fc44cbb533e32111f7058494b",
+  "testnetOperatorKey": "302e020100300506032b65700422042087592ee314bd0f42c4cf9f82b494481a2bb77bab0dc4454eedfe00f60168646f",
+  "testnetOperatorId": "0.0.458179",
+  "mainnetOperatorKey": "",
+  "mainnetOperatorId": ""
 }

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -114,7 +114,7 @@ async function createAccount(
     network: stateUtils.getNetwork(),
     alias,
     accountId: newAccountId.toString(),
-    type,
+    type: type.toUpperCase(),
     publicKey: newAccountPrivateKey.publicKey.toString(),
     evmAddress:
       type.toLowerCase() === 'ed25519'
@@ -259,7 +259,7 @@ async function getAccountBalance(
     process.exit(1);
   }
 
-  const response = await api.account.getAccountBalance(accountId);
+  const response = await api.account.getAccountInfo(accountId);
   display('displayBalance', response, { onlyHbar, tokenId });
 
   client.close();
@@ -267,7 +267,7 @@ async function getAccountBalance(
 }
 
 async function getAccountHbarBalance(accountId: string): Promise<number> {
-  const response = await api.account.getAccountBalance(accountId);
+  const response = await api.account.getAccountInfo(accountId);
 
   if (!response) {
     logger.error('Error getting account balance');


### PR DESCRIPTION
**Description**:
Add end-to-end testing for:
- Flow 1: touching multiple features (hbar, backup/import, account create and delete, setup init and network switching)
- Script flow: dedicated flow to loading scripts in state, executing them, removing them
- Token flow: create token from CLI, associate account, and transfer 1 unit

Closes #205 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
