### PR TITLE
Add "account view" command - Closes #208

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ account list
 account import
 account clear
 account delete
+account view
 ```
 
 #### Usage
@@ -406,6 +407,19 @@ Flags:
 
 - **-a, --alias:** (optional) Alias of the account to delete.
 - **-i, --id:** (optional) Account ID of the account to delete.
+
+**7. View Account Information:**
+
+Displays detailed information about a specified account by its ID. The account can be in the CLI's state or on the Hedera network.
+
+```sh
+hcli account view -i,--id <id>
+```
+
+Flags:
+
+- **-i, --id:** (required) Account ID to view.
+
 
 ## Token Commands
 

--- a/__tests__/commands/account/view.test.ts
+++ b/__tests__/commands/account/view.test.ts
@@ -1,0 +1,54 @@
+import { alice, baseState } from "../../helpers/state";
+import { Command } from "commander";
+import commands from "../../../src/commands";
+import api from "../../../src/api/";
+import stateController from "../../../src/state/stateController";
+import { accountResponse } from "../../helpers/api/apiAccountHelper";
+import { Logger } from "../../../src/utils/logger";
+
+const logger = Logger.getInstance();
+
+jest.mock("../../../src/state/state"); // Mock the original module -> looks for __mocks__/state.ts in same directory
+
+describe("account view command", () => {
+  const getAccountInfoSpy = jest.spyOn(api.account, "getAccountInfo").mockResolvedValue({
+    data: accountResponse,
+  });
+  const logSpy = jest.spyOn(logger, "log").mockImplementation();
+
+  beforeEach(() => {
+    stateController.saveState(baseState);
+  });
+
+  afterEach(() => {
+    getAccountInfoSpy.mockClear();
+    logSpy.mockClear();
+  });
+
+  describe("account view - success path", () => {
+    test("✅ should print account details for requested account ID", async () => {
+      // Arrange
+      const program = new Command();
+      commands.accountCommands(program);
+
+      // Act
+      await program.parse([
+        "node",
+        "hedera-cli.ts",
+        "account",
+        "view",
+        "-i",
+        accountResponse.account,
+      ]);
+
+      // Assert
+      expect(getAccountInfoSpy).toHaveBeenCalledWith(accountResponse.account);
+      expect(logSpy).toHaveBeenCalledWith(`Account: ${accountResponse.account}`);
+      expect(logSpy).toHaveBeenCalledWith(`Balance Tinybars: ${accountResponse.balance.balance}`);
+      expect(logSpy).toHaveBeenCalledWith(`Deleted: ${accountResponse.deleted}`);
+      expect(logSpy).toHaveBeenCalledWith(`EVM Address: ${accountResponse.evm_address}`);
+      expect(logSpy).toHaveBeenCalledWith(`Key type: ${accountResponse.key._type} - Key: ${accountResponse.key.key}`);
+      expect(logSpy).toHaveBeenCalledWith(`Max automatic token associations: ${accountResponse.max_automatic_token_associations}`);
+    });
+  });
+});

--- a/src/commands/account/index.ts
+++ b/src/commands/account/index.ts
@@ -4,6 +4,7 @@ import createCommand from './create';
 import importCommand from './import';
 import listCommand from './list';
 import clearCommand from './clear';
+import viewCommand from './view';
 
 export default (program: any) => {
   const account = program.command('account');
@@ -14,4 +15,5 @@ export default (program: any) => {
   importCommand(account);
   listCommand(account);
   clearCommand(account);
+  viewCommand(account);
 };

--- a/src/commands/account/view.ts
+++ b/src/commands/account/view.ts
@@ -1,0 +1,45 @@
+import stateUtils from '../../utils/state';
+import accountUtils from '../../utils/account';
+import dynamicVariablesUtils from '../../utils/dynamicVariables';
+import { Logger } from '../../utils/logger';
+
+import type { Command } from '../../../types';
+import api from '../../api';
+
+const logger = Logger.getInstance();
+
+export default (program: any) => {
+  program
+    .command('view')
+    .hook('preAction', (thisCommand: Command) => {
+      const command = [
+        thisCommand.parent.action().name(),
+        ...thisCommand.parent.args,
+      ];
+      stateUtils.recordCommand(command);
+    })
+    .description(
+      'View the detials of an account by accound ID. The account can be in the state or external.',
+    )
+    .requiredOption('-i, --id <id>', 'Account ID')
+    .action(async (options: ViewAccountOptions) => {
+      options = dynamicVariablesUtils.replaceOptions(options);
+      logger.verbose(`Viewing account ${options.id} details`);
+
+      try {
+        const response = await api.account.getAccountInfo(options.id);
+        logger.log(`Account: ${response.data.account}`);
+        logger.log(`Balance Tinybars: ${response.data.balance.balance}`);
+        logger.log(`Deleted: ${response.data.deleted}`);
+        logger.log(`EVM Address: ${response.data.evm_address}`);
+        logger.log(`Key type: ${response.data.key._type} - Key: ${response.data.key.key}`);
+        logger.log(`Max automatic token associations: ${response.data.max_automatic_token_associations}`);
+      } catch (error) {
+        logger.error('Failed to get account info:', error as object);
+      }
+    });
+};
+
+interface ViewAccountOptions {
+    id: string;
+}

--- a/src/commands/account/view.ts
+++ b/src/commands/account/view.ts
@@ -1,5 +1,4 @@
 import stateUtils from '../../utils/state';
-import accountUtils from '../../utils/account';
 import dynamicVariablesUtils from '../../utils/dynamicVariables';
 import { Logger } from '../../utils/logger';
 
@@ -32,8 +31,12 @@ export default (program: any) => {
         logger.log(`Balance Tinybars: ${response.data.balance.balance}`);
         logger.log(`Deleted: ${response.data.deleted}`);
         logger.log(`EVM Address: ${response.data.evm_address}`);
-        logger.log(`Key type: ${response.data.key._type} - Key: ${response.data.key.key}`);
-        logger.log(`Max automatic token associations: ${response.data.max_automatic_token_associations}`);
+        logger.log(
+          `Key type: ${response.data.key._type} - Key: ${response.data.key.key}`,
+        );
+        logger.log(
+          `Max automatic token associations: ${response.data.max_automatic_token_associations}`,
+        );
       } catch (error) {
         logger.error('Failed to get account info:', error as object);
       }
@@ -41,5 +44,5 @@ export default (program: any) => {
 };
 
 interface ViewAccountOptions {
-    id: string;
+  id: string;
 }


### PR DESCRIPTION
**Description**:
Ability to view account information for internal (CLI state) or external (Hedera network) accounts.

Closes #208 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit)
