### PR TITLE
Feature: Custom fees token support - Closes #187

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Flags:
 
 - **File:** (required) Filename containing the token information in JSON format.
 
-A token input file looks like below. You can define all properties you would normally define when using using the SDK to create a token. All of the properties are required. If you don't need a key, leave it as an empty string.
+A token input file looks like below. You can define all properties you would normally define when using using the SDK to create a token. All of the properties are required except for the min/max values for custom fractional fees. If you don't need a key, leave it as an empty string.
 
 ```json
 {
@@ -468,7 +468,23 @@ A token input file looks like below. You can define all properties you would nor
     "pauseKey": "",
     "kycKey": ""
   },
-  "customFees": [],
+  "customFees": [
+    {
+      "type": "fixed",
+      "unitType": "token",
+      "amount": 1,
+      "denom": "0.0.3609946",
+      "exempt": true,
+      "collectorId": "0.0.2221463"
+    },
+    {
+      "type": "fractional",
+      "numerator": 1,
+      "denominator": 100,
+      "exempt": true,
+      "collectorId": "0.0.2221463"
+    }
+  ],
   "memo": "Test token"
 }
 ```
@@ -476,6 +492,30 @@ A token input file looks like below. You can define all properties you would nor
 > **Note:** that you can use placeholders for all keys on a token. The format `<alias:bob>` refers to an account with alias `bob` in your address book. It will use Bob's key.
 >
 > You can also tell the CLI tool to create a new account with an account type (`ecdsa` or `ed25519`) and an initial balance in TinyBars. The `<newkey:ecdsa:10000>` placeholder creates a new ECDSA account with 10,000 TinyBars and uses its key for the admin key.
+
+Here's how custom fees are defined in the token input file:
+
+```json
+"customFees": [
+  {
+    "type": "fixed", // Indicates a fixed fee
+    "unitType": "token", // Indicates the denomination of the fee: "token", "hbar", or "tinybar"
+    "amount": 1, // Amount of the fee
+    "denom": "0.0.3609946", // If the unit type is "token", then you need to set a denominating token ID to collect the fees in
+    "exempt": true, // If true, exempts all the token's fee collector accounts from this fee.
+    "collectorId": "0.0.2221463" // Sets the fee collector account ID that collects the fee.
+  },
+  {
+    "type": "fractional", // Indicates a fractional fee
+    "numerator": 1, // Numerator of the fractional fee
+    "denominator": 100, // Denominator of the fractional fee: 1/100 = 1% fee on the transfer
+    "min": 1, // Optional: Minimum fee user has to pay
+    "max": 100, // Optional: Maximum fee user has to pay because fractional fees can become very costly
+    "exempt": true, // If true, exempts all the token's fee collector accounts from this fee.
+    "collectorId": "0.0.2221463" // Sets the fee collector account ID that collects the fee.
+  }
+]
+```
 
 **2. Create Fungible Token:**
 

--- a/__tests__/commands/token/create.test.ts
+++ b/__tests__/commands/token/create.test.ts
@@ -111,6 +111,7 @@ describe('token create command', () => {
           feeScheduleKey: '',
         },
         network: 'testnet',
+        customFees: [],
       } as Token);
       expect(saveKeyStateControllerSpy).toHaveBeenCalledWith(
         'tokens',

--- a/__tests__/helpers/state.ts
+++ b/__tests__/helpers/state.ts
@@ -91,6 +91,7 @@ export const token: Token = {
     treasuryKey:
       "302e020100300506032b657004220420ece0b15b20e555f66d5f4cd83187567af9613276629d7e15161b0c929ea07697",
   },
+  customFees: [],
 };
 
 export const topic: Topic = {

--- a/src/commands/token/create.ts
+++ b/src/commands/token/create.ts
@@ -99,6 +99,7 @@ async function createFungibleToken(
         feeScheduleKey: '',
       },
       network: stateUtils.getNetwork(),
+      customFees: [],
     },
   };
 

--- a/src/commands/token/createFromFile.ts
+++ b/src/commands/token/createFromFile.ts
@@ -1,5 +1,10 @@
 import * as path from 'path';
-import { TokenCreateTransaction, TokenType, PrivateKey, CustomFee } from '@hashgraph/sdk';
+import {
+  TokenCreateTransaction,
+  TokenType,
+  PrivateKey,
+  CustomFee,
+} from '@hashgraph/sdk';
 
 import accountUtils from '../../utils/account';
 import tokenUtils from '../../utils/token';
@@ -9,7 +14,15 @@ import { Logger } from '../../utils/logger';
 import stateController from '../../state/stateController';
 import dynamicVariablesUtils from '../../utils/dynamicVariables';
 
-import type { Account, Command, Token, Keys, CustomFeeInput, FixedFee, FractionalFee } from '../../../types';
+import type {
+  Account,
+  Command,
+  Token,
+  Keys,
+  CustomFeeInput,
+  FixedFee,
+  FractionalFee,
+} from '../../../types';
 import signUtils from '../../utils/sign';
 
 const logger = Logger.getInstance();
@@ -236,7 +249,7 @@ async function createTokenOnNetwork(token: Token) {
     addKeysToTokenCreateTx(tokenCreateTx, token);
 
     // Add custom fees
-    let fees: CustomFee[] = token.customFees.map(fee => {
+    let fees: CustomFee[] = token.customFees.map((fee) => {
       switch (fee.type) {
         case 'fixed':
           return feeUtils.createCustomFixedFee(fee as FixedFee);

--- a/src/commands/token/createFromFile.ts
+++ b/src/commands/token/createFromFile.ts
@@ -1,14 +1,15 @@
 import * as path from 'path';
-import { TokenCreateTransaction, TokenType, PrivateKey } from '@hashgraph/sdk';
+import { TokenCreateTransaction, TokenType, PrivateKey, CustomFee } from '@hashgraph/sdk';
 
 import accountUtils from '../../utils/account';
 import tokenUtils from '../../utils/token';
 import stateUtils from '../../utils/state';
+import feeUtils from '../../utils/fees';
 import { Logger } from '../../utils/logger';
 import stateController from '../../state/stateController';
 import dynamicVariablesUtils from '../../utils/dynamicVariables';
 
-import type { Account, Command, Token, Keys } from '../../../types';
+import type { Account, Command, Token, Keys, CustomFeeInput, FixedFee, FractionalFee } from '../../../types';
 import signUtils from '../../utils/sign';
 
 const logger = Logger.getInstance();
@@ -28,7 +29,7 @@ interface TokenInput {
   maxSupply: number;
   treasuryId?: string;
   treasuryKey: string;
-  customFees: [];
+  customFees: CustomFeeInput[];
   memo: string;
 }
 
@@ -77,6 +78,7 @@ function initializeToken(tokenInput: TokenInput): Token {
       feeScheduleKey: tokenInput.keys.feeScheduleKey,
       treasuryKey: tokenInput.keys.treasuryKey,
     },
+    customFees: tokenInput.customFees,
   };
 
   return token;
@@ -232,6 +234,21 @@ async function createTokenOnNetwork(token: Token) {
 
     // Add keys
     addKeysToTokenCreateTx(tokenCreateTx, token);
+
+    // Add custom fees
+    let fees: CustomFee[] = token.customFees.map(fee => {
+      switch (fee.type) {
+        case 'fixed':
+          return feeUtils.createCustomFixedFee(fee as FixedFee);
+        case 'fractional':
+          return feeUtils.createCustomFractionalFee(fee as FractionalFee);
+        default:
+          logger.error(`Unsupported fee type: ${fee.type}`);
+          client.close();
+          process.exit(1);
+      }
+    });
+    tokenCreateTx.setCustomFees(fees);
 
     // Signing
     tokenCreateTx.freezeWith(client);

--- a/src/input/token.template.json
+++ b/src/input/token.template.json
@@ -17,9 +17,18 @@
   },
   "customFees": [
     {
-      "amount": 100,
-      "unitType": "hbar",
+      "amount": 1,
+      "unitType": "token",
+      "denom": "0.0.3609946",
       "type": "fixed",
+      "exempt": true,
+      "collectorId": "0.0.2221463"
+    },
+    {
+      "type": "fractional",
+      "numerator": 1,
+      "denominator": 100,
+      "min": 1,
       "exempt": true,
       "collectorId": "0.0.2221463"
     }

--- a/src/input/token.template.json
+++ b/src/input/token.template.json
@@ -15,6 +15,14 @@
     "pauseKey": "",
     "kycKey": ""
   },
-  "customFees": [],
+  "customFees": [
+    {
+      "amount": 100,
+      "unitType": "hbar",
+      "type": "fixed",
+      "exempt": true,
+      "collectorId": "0.0.2221463"
+    }
+  ],
   "memo": "Test token"
 }

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -67,8 +67,8 @@ function createCustomFractionalFee(fee: FractionalFee): CustomFee {
 }
 
 const tokenUtils = {
-    createCustomFixedFee,
-    createCustomFractionalFee,
+  createCustomFixedFee,
+  createCustomFractionalFee,
 };
 
 export default tokenUtils;

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -1,0 +1,74 @@
+import {
+  CustomFixedFee,
+  CustomFractionalFee,
+  Hbar,
+  AccountId,
+  CustomFee,
+} from '@hashgraph/sdk';
+
+import { Logger } from './logger';
+
+import { FixedFee, FractionalFee } from '../../types';
+
+const logger = Logger.getInstance();
+
+function createCustomFixedFee(fee: FixedFee): CustomFee {
+  const customFee = new CustomFixedFee();
+
+  switch (fee.unitType.toLowerCase()) {
+    case 'hbar':
+    case 'hbars':
+      customFee.setHbarAmount(new Hbar(fee.amount));
+      break;
+    case 'tinybar':
+    case 'tinybars':
+      customFee.setHbarAmount(Hbar.fromTinybars(fee.amount));
+      break;
+    case 'token':
+    case 'tokens':
+      if (!fee.denom) {
+        logger.error('Token fee requires denom property');
+        process.exit(1);
+      }
+      customFee.setAmount(fee.amount);
+      customFee.setDenominatingTokenId(fee.denom);
+      break;
+    default:
+      logger.error(`Invalid fee unit type: ${fee.unitType}`);
+      process.exit(1);
+  }
+
+  if (fee.collectorId) {
+    customFee.setFeeCollectorAccountId(AccountId.fromString(fee.collectorId));
+  }
+  if (fee.exempt) {
+    customFee.setAllCollectorsAreExempt(fee.exempt);
+  }
+
+  return customFee;
+}
+
+function createCustomFractionalFee(fee: FractionalFee): CustomFee {
+  const customFee = new CustomFractionalFee()
+    .setNumerator(fee.numerator)
+    .setDenominator(fee.denominator);
+
+  if (fee.min) customFee.setMin(fee.min);
+  if (fee.max) customFee.setMax(fee.max);
+
+  if (fee.collectorId) {
+    customFee.setFeeCollectorAccountId(AccountId.fromString(fee.collectorId));
+  }
+  if (fee.exempt) {
+    customFee.setAllCollectorsAreExempt(fee.exempt);
+  }
+
+  return customFee;
+}
+
+const tokenUtils = {
+    createCustomFixedFee,
+    createCustomFractionalFee,
+};
+
+export default tokenUtils;

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -115,8 +115,6 @@ const transfer = async (
   client.close();
 };
 
-
-
 const tokenUtils = {
   getSupplyType,
   isTokenAssociated,

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -115,6 +115,8 @@ const transfer = async (
   client.close();
 };
 
+
+
 const tokenUtils = {
   getSupplyType,
   isTokenAssociated,

--- a/types/api/token.d.ts
+++ b/types/api/token.d.ts
@@ -5,7 +5,7 @@ export type TokenResponse = {
   auto_renew_account: string;
   auto_renew_period: number;
   created_timestamp: string;
-  custom_fees: CustomFees;
+  custom_fees: APICustomFees;
   decimals: string;
   deleted: boolean;
   expiry_timestamp: number;
@@ -30,19 +30,19 @@ export type TokenResponse = {
   wipe_key: Key;
 };
 
-interface CustomFees {
+interface APICustomFees {
   created_timestamp: string;
-  fixed_fees: FixedFee[];
-  fractional_fees: FractionalFee[];
+  fixed_fees: APIFixedFee[];
+  fractional_fees: APIFractionalFee[];
 }
 
-type FixedFee = {
+type APIFixedFee = {
   amount: number;
   collector_account_id: string;
   denominating_token_id: string;
 };
 
-type FractionalFee = {
+type APIFractionalFee = {
   amount: Fraction;
   collector_account_id: string;
   denominating_token_id: string;

--- a/types/state.d.ts
+++ b/types/state.d.ts
@@ -29,6 +29,28 @@ export type Script = {
   args: Record<string, string>;
 }
 
+interface Fee {
+  collectorId?: string;
+  exempt?: boolean;
+}
+
+export interface FixedFee extends Fee {
+  type: string;
+  unitType: string;
+  amount: number;
+  denom?: string;
+}
+
+export interface FractionalFee extends Fee {
+  type: string;
+  numerator: number;
+  denominator: number;
+  min?: number;
+  max?: number;
+}
+
+export type CustomFeeInput = FixedFee | FractionalFee;
+
 export type Token = {
   associations: Association[];
   tokenId: string;
@@ -41,6 +63,7 @@ export type Token = {
   maxSupply: number;
   keys: Keys;
   network: string;
+  customFees: CustomFeeInput[];
 }
 
 export interface Keys {


### PR DESCRIPTION
**Description**:
Allow users to add custom fees for tokens (fractional and fixed fees or a combination of multiple fees) to their token, created from an input file. 

```json
"customFees": [
    {
      "type": "fixed",
      "unitType": "token",
      "amount": 1,
      "denom": "0.0.3609946",
      "exempt": true,
      "collectorId": "0.0.2221463"
    },
    {
      "type": "fractional",
      "numerator": 1,
      "denominator": 100,
      "min": 1,
      "max": 5,
      "exempt": true,
      "collectorId": "0.0.2221463"
    }
  ]
```

**Related issue(s)**:

Closes #187 

**Checklist**

- [x] Documented (Code comments, README, etc.)
