### PR TITLE
fix: Add node command to bin property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "bin": {
-    "hedera-cli": "./dist/hedera-cli.js"
+    "hedera-cli": "node ./dist/hedera-cli.js"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Add node command to `bin.hedera-cli` to make it executable globally.
