### PR TITLE
ci: Update to use step-security maintained conventional-pr-title-action

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -42,6 +42,6 @@ jobs:
     runs-on: [self-hosted, Linux, medium, ephemeral]
     steps:
       - name: Check PR Title
-        uses: aslafy-z/conventional-pr-title-action@a0b851005a0f82ac983a56ead5a8111c0d8e044a # v3.2.0
+        uses: step-security/conventional-pr-title-action@0eae74515f5a79f8773fa04142dd746df76666ac # v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This pull request changes the following:

Updated source for conventional-pr-title-action

### Related Issues

- Closes #357 
