### PR TITLE
ci: Downgrade codecov-action to a stable version

### DIFF
--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -113,7 +113,7 @@ jobs:
           path: 'coverage/e2e'
 
       - name: Publish To Codecov
-        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
+        uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a # v5.0.2
         if: ${{ inputs.enable-codecov-analysis && !cancelled() && !failure() }}
         env:
           CODECOV_TOKEN: ${{ secrets.codecov-token }}


### PR DESCRIPTION
## Description

This pull request changes the following:

Downgrade codecov-action to a stable version

### Related Issues

- Closes #542
