### PR TITLE
chore(docs): Update balance options in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Flags:
 Displays the balance of a specified account. Users can choose to view only the Hbar balance or the balance of a specific token. It's not possible to use both options at once.
 
 ```sh
-hcli account balance <accountIdOrAlias> [-h,--only-hbar] [-t,--token-id <tokenId>]
+hcli account balance -a,--account-id-or-alias <accountIdOrAlias> [-h,--only-hbar] [-t,--token-id <tokenId>]
 
 // Output
 Balance for account 0.0.5892294:

--- a/src/commands/account/balance.ts
+++ b/src/commands/account/balance.ts
@@ -20,7 +20,7 @@ export default (program: any) => {
     .description('Retrieve the balance for an account ID or alias')
     .requiredOption(
       '-a, --account-id-or-alias <accountIdOrAlias>',
-      'Account ID or account alias to retrieve balance for',
+      '(Required) Account ID or account alias to retrieve balance for',
     )
     .option('-h, --only-hbar', 'Show only Hbar balance')
     .option('-t, --token-id <tokenId>', 'Show balance for a specific token ID')


### PR DESCRIPTION
## Description

Small mistake in the description for retrieve account balance options: -a is mandatory
