### PR TITLE
ci: replace action with step-security maintained version

### DIFF
--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -97,7 +97,7 @@ jobs:
         run: npm run unit-test
 
       - name: Publish Unit Test Report
-        uses: EnricoMi/publish-unit-test-result-action@afb2984f4d89672b2f9d9c13ae23d53779671984 # v2.19.0
+        uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
         if: ${{ inputs.enable-unit-tests && steps.npm-deps.conclusion == 'success' && !cancelled() }}
         with:
           check_name: 'Unit Test Results'
@@ -151,7 +151,7 @@ jobs:
         run: hedera stop
 
       - name: Publish E2E Test Report
-        uses: EnricoMi/publish-unit-test-result-action@afb2984f4d89672b2f9d9c13ae23d53779671984 # v2.19.0
+        uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
         if: ${{ inputs.enable-e2e-tests && steps.npm-deps.conclusion == 'success' && !cancelled() }}
         with:
           check_name: 'E2E Test Results'


### PR DESCRIPTION
## Description

This pull request changes the following:

- replaces EnricoMi/publish-unit-test-result-action with step-security version

### Related Issues

- Closes #654 
