### PR TITLE
feat: Embed hardhat commands in CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ _Note: If you configure an account but don't provide a URL or accounts array, th
 To run a script, make sure to point to the `dist` folder (after running `npm run build`) and use the `hardhat run` command. For example, to deploy the `erc721.sol` contract, you can run the following command in the root of the CLI tool:
 
 ```sh
-npx hardhat run ./dist/contracts/scripts/deploy.js
+hcli hardhat run ./dist/contracts/scripts/deploy.js
 ```
 
 ### Integrating Hardhat with the CLI Scripts Feature
@@ -344,9 +344,9 @@ The script feature let's you execute script blocks. Here's how you can integrate
       "name": "deploy",
       "creation": 1742830623351,
       "commands": [
-        "smartcontract compile",
-        "npx hardhat run ./dist/contracts/scripts/deploy.js",
-        "npx hardhat run ./dist/contracts/scripts/mint.js"
+        "hardhat compile",
+        "hardhat run ./dist/contracts/scripts/deploy.js",
+        "hardhat run ./dist/contracts/scripts/mint.js"
       ],
       "args": {}
     }
@@ -388,8 +388,8 @@ As mentioned, you can build interesting script blocks that combine regular CLI c
 {
   "name": "hardhat-deploy",
   "commands": [
-    "npx hardhat compile",
-    "npx hardhat run ./dist/contracts/scripts/deploy.js --network local", // stores the contract ID as "erc721address" in the script args
+    "hardhat compile",
+    "hardhat run ./dist/contracts/scripts/deploy.js --network local", // stores the contract ID as "erc721address" in the script args
     "account create -a {{erc721address}}" // Create a new account and set the alias name equal to the contract address (just an example)
   ],
   "args": {}
@@ -1112,7 +1112,7 @@ This example shows how to use Hardhat scripts as part of your flow, mixing it wi
   "commands": [
     "account create -a random --args privateKey-->privKeyAcc1 --args alias-->aliasAcc1 --args accountId-->idAcc1",
     "wait 3",
-    "npx hardhat run ./dist/contracts/scripts/deploy.js --network local"
+    "hardhat run ./dist/contracts/scripts/deploy.js --network local"
   ],
   "args": {}
 }

--- a/README.md
+++ b/README.md
@@ -328,10 +328,18 @@ _Note: If you configure an account but don't provide a URL or accounts array, th
 
 ### Running Hardhat Scripts
 
+If you have added new Hardhat scripts to `src/contracts/scripts`, you need to compile the contracts first. You can do this by running the following command in the root of the CLI tool:
+
+```sh
+npx hardhat compile
+```
+
+This command compiles the contracts and generates the necessary artifacts in the `dist/contracts` folder. The compiled contracts will be used by the Hardhat scripts to deploy and interact with the contracts.
+
 To run a script, make sure to point to the `dist` folder (after running `npm run build`) and use the `hardhat run` command. For example, to deploy the `erc721.sol` contract, you can run the following command in the root of the CLI tool:
 
 ```sh
-hcli hardhat run ./dist/contracts/scripts/deploy.js
+npx hardhat run ./dist/contracts/scripts/deploy.js --network local
 ```
 
 ### Integrating Hardhat with the CLI Scripts Feature

--- a/src/commands/script/load.ts
+++ b/src/commands/script/load.ts
@@ -31,8 +31,8 @@ function loadScript(name: string) {
   script.commands.forEach((command) => {
     logger.log(`\nExecuting command: \t${command}`);
 
-    if (command.startsWith('npx')) {
-      // If the command starts with 'npx', we can execute it directly
+    if (command.startsWith('hardhat')) {
+      // If the command starts with 'hardhat', we can execute it directly by adding 'npx'
       // Verify that the command is safe to execute
       if (command.includes('&&') || command.includes(';')) {
         logger.error('Unsafe command detected. Please check the script.');

--- a/src/state/base_state.json
+++ b/src/state/base_state.json
@@ -31,10 +31,10 @@
       "name": "erc721",
       "creation": 1742830623351,
       "commands": [
-        "npx hardhat compile",
-        "npx hardhat run ./dist/contracts/scripts/deploy.js --network local",
-        "npx hardhat run ./dist/contracts/scripts/mint.js --network local",
-        "npx hardhat run ./dist/contracts/scripts/balance.js --network local"
+        "hardhat compile",
+        "hardhat run ./dist/contracts/scripts/deploy.js --network local",
+        "hardhat run ./dist/contracts/scripts/mint.js --network local",
+        "hardhat run ./dist/contracts/scripts/balance.js --network local"
       ],
       "args": {}
     }

--- a/src/state/test_state.json
+++ b/src/state/test_state.json
@@ -32,10 +32,10 @@
       "name": "erc721",
       "creation": 1742830623351,
       "commands": [
-        "npx hardhat compile",
-        "npx hardhat run ./dist/contracts/scripts/deploy.js --network local",
-        "npx hardhat run ./dist/contracts/scripts/mint.js --network local",
-        "npx hardhat run ./dist/contracts/scripts/balance.js --network local"
+        "hardhat compile",
+        "hardhat run ./dist/contracts/scripts/deploy.js --network local",
+        "hardhat run ./dist/contracts/scripts/mint.js --network local",
+        "hardhat run ./dist/contracts/scripts/balance.js --network local"
       ],
       "args": {}
     }


### PR DESCRIPTION
## Description

Before, you would write "npx hardhat run ..." in the script blocks.
We've updated this to just "hardhat" and add the "npx" part when actually executing the command. 
This is a small DX improvement + update for the docs. 
