### PR TITLE
feat: Allow account backups to be restored and discovered

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,25 @@ Loads a script by name from state and sequentially executes each command in the 
 hcli script load -n,--name <name>
 ```
 
-Each command is executed via [`execSync`](https://nodejs.org/api/child_process.html), which runs the command in a synchronous child process.
+Each command is executed via [`execSync`](https://nodejs.org/api/child_process.html), which runs the command in a synchronous child process. Scripts are stored in the `dist/state.json` file, in the `scripts` section. 
+
+**Make sure to append each script with `script-` prefix. The name of the script is just the name without the `script-` prefix.** If you want to load this script, you use `hcli script load -n erc721`, without the `script-` prefix.
+
+```
+"scripts": {
+    "script-erc721": {
+      "name": "erc721",
+      "creation": 1742830623351,
+      "commands": [
+        "hardhat compile",
+        "hardhat run ./dist/contracts/scripts/erc721/deploy.js --network local",
+        "hardhat run ./dist/contracts/scripts/erc721/mint.js --network local",
+        "hardhat run ./dist/contracts/scripts/erc721/balance.js --network local"
+      ],
+      "args": {}
+    }
+}
+```
 
 **2. List All Scripts:**
 

--- a/README.md
+++ b/README.md
@@ -867,7 +867,7 @@ Flags:
 
 **2. Restoring Backup:**
 
-This command restores a backup of the `state.json` file stored in the same `dist/state` directory, it can't detect backups stored elsewhere. It only restores state files with the format `state.backup.<timestamp>.json`. If you don't provide a filename, the CLI tool will list all available backups and ask you to select one.
+This command restores a backup of the `state.json` file stored in the same `dist/state` directory, it can't detect backups stored elsewhere. It only restores state files with the format `*.backup.*.json`. If you don't provide a filename, the CLI tool will list all available backups that match this pattern and ask you to select one.
 
 ```sh
 hcli backup restore -f,--file <filename> [--restore-accounts] [--restore-tokens] [--restore-scripts]
@@ -884,6 +884,12 @@ Example: You can combine the flags to restore only certain parts of the state. F
 
 ```sh
 hcli backup restore -f state.backup.1704321015228.json --restore-accounts --restore-tokens
+```
+
+You can also restore an account backup by using the following command (which restores only the accounts section of the state):
+
+```sh
+hcli backup restore -f accounts.backup.7-nov-2024.json
 ```
 
 > **Note: If you don't provide a filename, the CLI tool will list all available backups and ask you to select one.** You can still use the flags to restore only certain parts of the state.

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -213,8 +213,8 @@ export default (program: any) => {
       if (!options.file) {
         const files = fs.readdirSync(path.join(__dirname, '..', 'state'));
 
-        // filter out the pattern state.backup.TIMESTAMP.json
-        const pattern = /^state\.backup\.\d+\.json$/;
+        // filter out the pattern *.backup.*.json like accounts.backup.7-nov-2024.json
+        const pattern = /^.*\.backup\..*\.json$/;
         const backups = files.filter((file) => pattern.test(file));
 
         if (backups.length === 0) {

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -46,6 +46,12 @@ function filterState(data: State) {
     filteredState.accounts[alias].privateKey = '';
   });
 
+  // Remove private keys from topics
+  Object.keys(filteredState.topics).forEach((topicId) => {
+    filteredState.topics[topicId].adminKey = '';
+    filteredState.topics[topicId].submitKey = '';
+  }); 
+
   return filteredState;
 }
 

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -124,22 +124,20 @@ function restoreState(
 ) {
   let data;
 
-  // Only allow state backups to be restored, not account, token, or script backups (for now)
-  if (
-    filename.includes('accounts') ||
-    filename.includes('tokens') ||
-    filename.includes('scripts')
-  ) {
-    logger.error('Only state backups can be restored');
-    process.exit(1);
-  }
-
   try {
     const backupPath = path.join(__dirname, '..', 'state', filename);
     data = JSON.parse(fs.readFileSync(backupPath, 'utf8')) as State;
   } catch (error) {
     logger.error('Unable to read backup file:', error as object);
     process.exit(1);
+  }
+
+  // If the backup file does not contain a network, we assume it is an account backup
+  if (!data.accounts) {
+    logger.log('Importing account backup');
+    stateController.saveKey('accounts', data || {});
+    logger.log('Account backup restored successfully');
+    return;
   }
 
   if (!restoreAccounts && !restoreTokens && !restoreScripts) {

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -46,8 +46,6 @@ function filterState(data: State) {
     filteredState.accounts[alias].privateKey = '';
   });
 
-  logger.log('Warning: The private keys were not removed from scripts');
-
   return filteredState;
 }
 
@@ -89,6 +87,9 @@ function backupState(
   // Only backup accounts if the user specified the --accounts flag
   if (backupAccounts) {
     backupFilename = `accounts.backup.${timestamp}.json`;
+    if (name) {
+      backupFilename = `accounts.backup.${name}.json`;
+    }
     data = data.accounts;
   }
 
@@ -122,6 +123,17 @@ function restoreState(
   restoreScripts: boolean,
 ) {
   let data;
+
+  // Only allow state backups to be restored, not account, token, or script backups (for now)
+  if (
+    filename.includes('accounts') ||
+    filename.includes('tokens') ||
+    filename.includes('scripts')
+  ) {
+    logger.error('Only state backups can be restored');
+    process.exit(1);
+  }
+
   try {
     const backupPath = path.join(__dirname, '..', 'state', filename);
     data = JSON.parse(fs.readFileSync(backupPath, 'utf8')) as State;


### PR DESCRIPTION
## Description

Currently, the CLI tool only allows for full state backups to be restored again. Now the tool also checks which kind of backup it's dealing with and restores both state and account backups. It also allows for custom naming following the format `*.backup.*.json` like `accounts.backup.24-nov-2025.json`. 

Also, the `--safe` option now also cleans the keys from the `topic` key in the state.

### Related Issues

- Closes #517 
